### PR TITLE
Signatures translation - basic structure & multiplicity

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -46,58 +46,61 @@ class State(ABC):
         logging.info(f"{self._state} => {state}")
         self._state = state
 
-class Signature(ABC):
-    def __init__(self, sig_name: str = "Signature", name: str = None) -> None:
-        if name is None:
-            self._name = self.__class__.__name__
+
+class Signature:
+    name = "default_signature_name"
+    _value = {}
+
+    def __init__(self, name, multiplicity=None, cardinality=1):
+        self.name = name
+        if not multiplicity:
+            self.lower = 0
+            self.upper = None
+        elif multiplicity == "one":
+            self.lower = 1
+            self.upper = 1
+        elif multiplicity == "some":
+            self.lower = 1
+            self.upper = None
+        elif multiplicity == "lone":
+            self.lower = 0
+            self.upper = 1
+        elif multiplicity == "set":
+            self.lower = 0
+            self.upper = None
         else:
-            self._name = name
-        self._sig_name = sig_name
+            self.lower = 0
+            self.upper = None
+        value = {name + str(i + 1) for i in range(cardinality)}
+        if self.set_value(value) is None:
+            raise Exception("Invalid initial value for signature: " + name)
+
+    def check_validity(self, value) -> bool:
+        assert isinstance(value, set), "Signature has to be a set"
+        if self.upper:
+            return self.lower <= len(value) <= self.upper
+        else:
+            return self.lower <= len(value)
+
+    def get_value(self):
+        return self._value
+
+    # Returns None if the value intended to be set is invalid
+    def set_value(self, value):
+        if self.check_validity(value):
+            self._value = value
+            return self._value
+        else:
+            return None
 
     def __repr__(self):
-        return f"{self._sig_name} {self._name}"
-
-    def __key(self):
-        return self._sig_name + self._name
-
-    def __hash__(self):
-        return hash(self.__key())
-
-    def __eq__(self, other):
-        if isinstance(other, Signature):
-            return self.__key() == other.__key()
-        return False
-
-
-# Model "one sig" as singleton classes
-class Singleton(type(Signature)):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-        cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+        return f"{self.name} {self._value}"
 
 # --- Signatures ---
 
-#foreach($label in $basicSigLabels)
-class $label(Signature):
-    def __init__(self, name: str = None) -> None:
-        super().__init__("${label}", name)
-
+#foreach($signature in $signatures)
+${signature.Name} = Signature("${signature.Name}", "${signature.Multiplicity}", ${signature.Cardinality})
 #end
-
-#foreach($label in $oneSigLabels)
-class $label(Signature, metaclass=Singleton):
-    def __init__(self):
-        self._abbrev = '${label.charAt(0)}'
-
-    def __repr__(self):
-        return f"$label(${label.charAt(0)})"
-
-
-#end
-
 
 # --- Conc States ---
 #macro(generateState $concState $padding)
@@ -108,7 +111,7 @@ $padding     # substates
 		#set($newpadding = "$padding$tab")
 		#generateState($substate $newpadding)
 	#end
-	
+
 $padding    """ The wrapper state for ${concState.getName()} """
 
 $padding    def __init__(self, context: State, root_context: State) -> None:
@@ -148,8 +151,8 @@ $padding            self._context.change_state(self._context.${trans.getFromStat
 $padding            return True
 
         #end
- 
-#end 
+
+#end
 
 #foreach($concState in $concStateList)
 	#generateState($concState "")

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -20,11 +20,25 @@ public class DashPythonTranslation {
 
     private DashModule dashModule;
 
-    public List<String> basicSigLabels;
-
-    public List<String> oneSigLabels;
+    public List<Signature> signatures;
 
     private Map<String, State> concStateMap;
+
+    public class Signature {
+        public String name;
+        public String multiplicity;
+        public int cardinality;
+
+        public Signature(String name, String multiplicity, int cardinality) {
+            this.name = name;
+            this.multiplicity = multiplicity;
+            this.cardinality = cardinality;
+        }
+
+        public String getName() { return name; }
+        public String getMultiplicity() { return multiplicity; }
+        public int getCardinality() { return cardinality; }
+    }
 
     /**
      * Constructs a new DashPythonTranslation object
@@ -34,15 +48,8 @@ public class DashPythonTranslation {
         this.dashModule = dashModule;
 
         // get signature names
-        this.basicSigLabels = dashModule.sigs.values().stream()
-                .filter(this::isSubSig)
-                .map(sig -> clean(sig.label))
-                .collect(Collectors.toList());
-
-        // get signature names
-        this.oneSigLabels = dashModule.sigs.values().stream()
-                .filter(this::isOneSig)
-                .map(sig -> clean(sig.label))
+        this.signatures = dashModule.sigs.values().stream()
+                .map(sig -> new Signature(clean(sig.label), getMultiplicity(sig), getCardinality(sig)))
                 .collect(Collectors.toList());
 
         // get state hierarchy
@@ -82,16 +89,20 @@ public class DashPythonTranslation {
         }
     }
 
-    private Boolean isSubSig(Sig sig) {
-        return sig.isSubsig != null & sig.isOne == null & sig.isAbstract == null & sig.isEnum == null &
-                sig.isLone == null & sig.isMeta == null & sig.isPrivate == null & sig.isSome == null & sig.isSubset == null &
-                sig.isVariable == null;
+    private String getMultiplicity(Sig sig) {
+        if (sig.isLone != null)
+            return "lone";
+        if (sig.isOne != null)
+            return "one";
+        if (sig.isSome != null)
+            return "some";
+        return "set";
     }
 
-    private Boolean isOneSig(Sig sig) {
-        return sig.isOne != null & sig.isAbstract == null & sig.isEnum == null &
-                sig.isLone == null & sig.isMeta == null & sig.isPrivate == null & sig.isSome == null & sig.isSubset == null &
-                sig.isVariable == null;
+    private int getCardinality(Sig sig) {
+        if (sig.isOne !=null || sig.isLone != null)
+            return 1;
+        return 3;
     }
 
     // return all states that aren't substates (to prevent them from appearing multiple times)

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
@@ -29,8 +29,7 @@ public class CoreDashToPython {
         // add to template file
 
         // add signatures
-        vc.put("basicSigLabels", dashPythonTranslation.basicSigLabels);
-        vc.put("oneSigLabels", dashPythonTranslation.oneSigLabels);
+        vc.put("signatures", dashPythonTranslation.signatures);
 
         // add concurrent states
         vc.put("concStateList", dashPythonTranslation.getStates());

--- a/org.alloytools.alloy.dash/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.dash/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -69,15 +69,28 @@ public class DashPythonTranslationTest {
 
     @Test
     public void testSignatures() throws Exception {
-        String dashModel = " sig Patient {} sig Medication {}";
+        String dashModel = "sig Floor {}\n" +
+                "one sig Chicken {}\n" +
+                "some sig SomeSig {}\n" +
+                "lone sig LoneSig {}";
 
         DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
         DashToCoreDash.transformToCoreDash(dashModule);
 
         DashPythonTranslation translation = new DashPythonTranslation(dashModule);
 
-        assertEquals(2, translation.basicSigLabels.size());
-        assertTrue(translation.basicSigLabels.contains("Patient"));
-        assertTrue(translation.basicSigLabels.contains("Medication"));
+        assertEquals(4, translation.signatures.size());
+        assertEquals(translation.signatures.get(0).name, "Floor");
+        assertEquals(translation.signatures.get(0).multiplicity, "set");
+        assertEquals(translation.signatures.get(0).cardinality, 3);
+        assertEquals(translation.signatures.get(1).name, "Chicken");
+        assertEquals(translation.signatures.get(1).multiplicity, "one");
+        assertEquals(translation.signatures.get(1).cardinality, 1);
+        assertEquals(translation.signatures.get(2).name, "SomeSig");
+        assertEquals(translation.signatures.get(2).multiplicity, "some");
+        assertEquals(translation.signatures.get(2).cardinality, 3);
+        assertEquals(translation.signatures.get(3).name, "LoneSig");
+        assertEquals(translation.signatures.get(3).multiplicity, "lone");
+        assertEquals(translation.signatures.get(3).cardinality, 1);
     }
 }

--- a/org.alloytools.alloy.dash/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.dash/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -23,4 +23,26 @@ public class CoreDashToPythonTest {
 
         assertNotNull(CoreDashToPython.toString(translation));
     }
+
+    @Test
+    public void testSignatures() throws IOException {
+        String dashModel = "sig Floor {}\n" +
+                "sig Medication {}\n" +
+                "one sig Chicken, Farmer, Fox, Grain {}\n" +
+                "some sig SomeSig {}\n" +
+                "lone sig LoneSig {}";
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        DashToCoreDash.transformToCoreDash(dashModule);
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule);
+
+        String expectedTranslation = "Floor = Signature(\"Floor\", \"set\", 3)\n" +
+                "Medication = Signature(\"Medication\", \"set\", 3)\n" +
+                "Chicken = Signature(\"Chicken\", \"one\", 1)\n" +
+                "Farmer = Signature(\"Farmer\", \"one\", 1)\n" +
+                "Fox = Signature(\"Fox\", \"one\", 1)\n" +
+                "Grain = Signature(\"Grain\", \"one\", 1)\n" +
+                "SomeSig = Signature(\"SomeSig\", \"some\", 3)\n" +
+                "LoneSig = Signature(\"LoneSig\", \"lone\", 1)";
+        assert (CoreDashToPython.toString(translation).contains(expectedTranslation));
+    }
 }


### PR DESCRIPTION
Translate all signatures to customized data objects with underlying being only sets.
Create getter and setter functions so all signatures can be interacted with in expressions & transitions. (The result won't be correct, as subsets relationship hasn't been implemented yet. But the basic structure is here, so it shouldn't block any other ticket.)
More functionality & constraints that come with signatures to be added later.

Feel free to change the interface and/or override functions.