### PR TITLE
translate simple do expressions and add test cases for when & do expr

### DIFF
--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -35,6 +35,7 @@ public class DashExprToPython<ExprType> {
             sb.append(genExpr(((DashWhenExpr)this.specialExpr).expr, ((DashWhenExpr)this.specialExpr).exprList.size()));
         } else if (specialExpr instanceof DashDoExpr){
             // TODO: Do expr should be different since actions are needed, not just evaluation statements
+            sb.append(genExpr(((DashDoExpr)this.specialExpr).expr, ((DashDoExpr)this.specialExpr).exprList.size()));
         }
     }
 
@@ -56,6 +57,9 @@ public class DashExprToPython<ExprType> {
             ExprBinary binaryNode = (ExprBinary) node;
             return(BinaryOp2PythonOp(binaryNode));
         } else if (node instanceof ExprVar){
+            if('\'' == node.toString().charAt(node.toString().length() - 1)){
+                return node.toString().substring(0, node.toString().length() - 1);
+            }
             return node.toString();
         }else{
             // under development, use this to catch more types that could be useful
@@ -83,7 +87,7 @@ public class DashExprToPython<ExprType> {
             case EXACTLYOF:
                 res = " ";
                 break;
-            case NOT:        // TODO: this part assumes the inner expression is a statement that evaluates to true or false
+            case NOT:        // this part assumes the inner expression is a statement that evaluates to true or false
                 res = "not(" + this.genExpr(node,1) + ")";
                 break;
             case AFTER:
@@ -104,10 +108,10 @@ public class DashExprToPython<ExprType> {
             case ONCE:
                 res = " ";
                 break;
-            case NO:        // TODO: this part assumes the inner expression is a signature instance that is an object
+            case NO:        // this part assumes the inner expression is a signature instance that is an object
                 res = this.genExpr(node,1) + " is None";
                 break;
-            case SOME:      // TODO: this part assumes the inner expression is a signature instance that is an object
+            case SOME:      // this part assumes the inner expression is a signature instance that is an object
                 res = this.genExpr(node,1) + " is not None";
                 break;
             case LONE:
@@ -138,7 +142,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case NOOP:
-                res = "";
+                res = this.genExpr(node, 1);
                 break;
         }
         return res;
@@ -147,6 +151,7 @@ public class DashExprToPython<ExprType> {
     // translate Binary operation, also returns the empty space
     private String BinaryOp2PythonOp(ExprBinary node){
         String res = " ";
+        boolean addParanthesis = false;
         switch(node.op){
             case ARROW:
                 res = " ";
@@ -214,14 +219,14 @@ public class DashExprToPython<ExprType> {
             case PLUSPLUS:
                 res = " ";
                 break;
-            case PLUS:        // TODO: this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " | " + this.genExpr(node.right, 1);
+            case PLUS:        // this part assumes inner expression are a signature instances and are sets
+                res = this.genExpr(node.left, 1) + " | ";
                 break;
             case IPLUS:
                 res = " ";
                 break;
-            case MINUS:        // TODO: this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " - " + this.genExpr(node.right, 1);
+            case MINUS:        // this part assumes inner expression are a signature instances and are sets
+                res = this.genExpr(node.left, 1) + " - ";
                 break;
             case IMINUS:
                 res = " ";
@@ -235,38 +240,38 @@ public class DashExprToPython<ExprType> {
             case REM:
                 res = " ";
                 break;
-            case EQUALS:        // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " == " + this.genExpr(node.right, 1);
+            case EQUALS:        // this part assumes inner expression are a signature instances and are sets,
+                res = this.genExpr(node.left, 1) + " = ";
                 break;
-            case NOT_EQUALS:    // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " != " + this.genExpr(node.right, 1);
+            case NOT_EQUALS:    // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " != ";
                 break;
             case IMPLIES:
                 res = " ";
                 break;
-            case LT:         // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " < " + this.genExpr(node.right, 1);
+            case LT:         // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " < ";
                 break;
-            case LTE:        // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " <= " + this.genExpr(node.right, 1);
+            case LTE:        // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " <= ";
                 break;
-            case GT:         // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " > " + this.genExpr(node.right, 1);
+            case GT:         // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " > ";
                 break;
-            case GTE:        // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " >= " + this.genExpr(node.right, 1);
+            case GTE:        // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " >= ";
                 break;
-            case NOT_LT:     // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " >= " + this.genExpr(node.right, 1);
+            case NOT_LT:     // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " >= ";
                 break;
-            case NOT_LTE:    // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " > " + this.genExpr(node.right, 1);
+            case NOT_LTE:    // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " > ";
                 break;
-            case NOT_GT:     // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " <= " + this.genExpr(node.right, 1);
+            case NOT_GT:     // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " <= ";
                 break;
-            case NOT_GTE:    // TODO: this part assumes this part assumes inner expression are a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " < " + this.genExpr(node.right, 1);
+            case NOT_GTE:    // this part assumes inner expression are a signature instances and are comparable
+                res = this.genExpr(node.left, 1) + " < ";
                 break;
             case SHL:
                 res = " ";
@@ -277,17 +282,19 @@ public class DashExprToPython<ExprType> {
             case SHR:
                 res = " ";
                 break;
-            case IN:            // TODO: this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + ".issubset(" + this.genExpr(node.right, 1) + ")";
+            case IN:            // this part assumes inner expression are a signature instances and are sets
+                res = this.genExpr(node.left, 1) + ".issubset";
+                addParanthesis = true;
                 break;
-            case NOT_IN:        // TODO: this part assumes inner expression are a signature instances and are sets
-                res = "not(" + this.genExpr(node.left, 1) + ".issubset(" + this.genExpr(node.right, 1) + "))";
+            case NOT_IN:        // this part assumes inner expression are a signature instances and are sets
+                res = "not " + this.genExpr(node.left, 1) + ".issubset";
+                addParanthesis = true;
                 break;
-            case AND:           // TODO: this part assumes the inner expression is a statement that evaluates to true or false
-                res = "(" + this.genExpr(node.left, 1) + ") and (" + this.genExpr(node.right, 1) + ")";
+            case AND:           // this part assumes the inner expression is a statement that evaluates to true or false
+                res = "(" + this.genExpr(node.left, 1) + ") and ";
                 break;
-            case OR:            // TODO: this part assumes the inner expression is a statement that evaluates to true or false
-                res = "(" + this.genExpr(node.left, 1) + ") or (" + this.genExpr(node.right, 1) + ")";
+            case OR:            // this part assumes the inner expression is a statement that evaluates to true or false
+                res = "(" + this.genExpr(node.left, 1) + ") or ";
                 break;
             case IFF:
                 res = " ";
@@ -304,6 +311,13 @@ public class DashExprToPython<ExprType> {
             case TRIGGERED:
                 res = " ";
                 break;
+        }
+
+        // add paranthesis for right node
+        if(addParanthesis || node.right instanceof ExprBinary){
+            res += "(" + this.genExpr(node.right, 1) + ")";
+        }else{
+            res += this.genExpr(node.right, 1);
         }
         return res;
     }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -166,10 +166,10 @@ public class DashPythonTranslation {
             }
             if(dashTrans.doExpr != null){      // determines the action
                 // TODO: need to be able to translate the actions first
-                // String predicate = ...;
+                DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.doExpr);
 
                 // set action
-                this.action = "pass\t# <placeholder for Action>";
+                this.action = dashExprTranslator.toString();
             }
             if(dashTrans.gotoExpr != null){    // determine the next state
                 this.toStateName = dashTrans.gotoExpr.toString();

--- a/org.alloytools.alloy.dash/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.dash/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -7,9 +7,7 @@ import ca.uwaterloo.watform.transform.DashToCoreDash;
 import edu.mit.csail.sdg.alloy4.A4Reporter;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -89,4 +87,81 @@ public class DashPythonTranslationTest {
         assertTrue(translation.basicSigLabels.contains("Patient"));
         assertTrue(translation.basicSigLabels.contains("Medication"));
     }
+
+    @Test
+    public void testWhenExpr_1() throws Exception {
+        String dashModel = "abstract sig Object {} one sig SigA, SigB extends Object {} conc state StateA { " +
+                "near: set Object far: set Object \n" +
+                "trans trans_When_test_in { when SigA in near } \n" +
+                "trans trans_When_test_not_in { when SigA not in near } \n" +
+                "trans trans_When_test_unary_not_2 { when !(SigA not in near) }\n" +
+                "trans trans_When_test_unequal { when SigA != SigB }\n" +
+                "trans trans_When_test_unary_not_1 { when !(SigA) }\n" +
+                "trans trans_When_test_unequal_bang {when !(SigA != SigB)} }";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        DashToCoreDash.transformToCoreDash(dashModule);
+
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule);
+
+        List<DashPythonTranslation.Transition> transitions = translation.getStates().get(0).getTransitions();
+        assertEquals( 6,transitions.size());
+
+        List<String> expectedString = Arrays.asList(
+                "SigA.issubset(near)",
+                "not SigA.issubset(near)",
+                "not(not SigA.issubset(near))",
+                "SigA != SigB",
+                "not(SigA)",
+                "not(SigA != SigB)");
+
+        for(int index = 0; index < transitions.size(); index++){
+            assertEquals(expectedString.get(index), transitions.get(index).getGuardCondition());
+        }
+    }
+
+    @Test
+    public void testDoExpr_1() throws Exception {
+        String dashModel = "abstract sig Object {} one sig SigA, SigB extends Object {} conc state StateA {near: set Object far: set Object direction: one Direction\n" +
+                "trans trans_Do_assign_assign_without_brace_no { do far = far }\n" +
+                "trans trans_Do_assign_assign_without_brace {do far' = far}\n" +
+                "trans trans_Do_assign_assign_with_brace {do{ far' = far} }\n" +
+                "trans trans_Do_assign_assign_union_2 {do{ far' = far + SigA} }\n" +
+                "trans trans_Do_assign_assign_union_3 {do{ far' = far + SigA + SigB} }\n" +
+                "trans trans_Do_assign_assign_union_3_paren_1 {do{ far' = (far + SigA) + SigB} }\n" +
+                "trans trans_Do_assign_assign_union_3_paren_2 {do{ far' = far + (SigB + SigA)} }\n" +
+                "trans trans_Do_assign_assign_subtract_2 {do{ far' = far - SigA} }\n" +
+                "trans trans_Do_assign_assign_subtract_3 {do{ far' = far - SigA - SigB} }\n" +
+                "trans trans_Do_assign_assign_subtract_3_paren_1 {do{ far' = (far - SigA) - SigB} }\n" +
+                "trans trans_Do_assign_assign_subtract_3_paren_2 {do{ far' = far - (SigA - SigB)} }\n" +
+                "trans trans_Do_assign_assign_4_paren {do{ far' = ((far + SigA) - (SigB - far))} }\n" +
+                "}";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        DashToCoreDash.transformToCoreDash(dashModule);
+
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule);
+
+        List<DashPythonTranslation.Transition> transitions = translation.getStates().get(0).getTransitions();
+        assertEquals(12, transitions.size());
+
+        List<String> expectedString = Arrays.asList(
+                "far = far",
+                "far = far",
+                "far = far",
+                "far = (far | SigA)",
+                "far = (far | SigA | SigB)",
+                "far = (far | SigA | SigB)",
+                "far = (far | (SigB | SigA))",
+                "far = (far - SigA)",
+                "far = (far - SigA - SigB)",
+                "far = (far - SigA - SigB)",
+                "far = (far - (SigA - SigB))",
+                "far = (far | SigA - (SigB - far))");
+
+        for (int index = 0; index < transitions.size(); index++) {
+            assertEquals(expectedString.get(index), transitions.get(index).getAction());
+        }
+    }
+
 }


### PR DESCRIPTION
Add test cases
Translate assignment expressions (`=`) including `+` and `-`

This PR has some conflicts with [translate init](https://github.com/WatForm/org.alloytools.alloy/pull/17) about `EQUALS`, will need that PR to be merged first and solve the conflicts in this PR.