### PR TITLE
Add Central Controller + Events

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -45,6 +45,21 @@ class State(ABC):
     def change_state(self, state: State):
         logging.info(f"{self._state} => {state}")
         self._state = state
+        
+    def handleEvent(self, eventName: str):
+        possible_transitions = []
+        for k, v in self.transitions.items():
+            if k(eventName):
+                possible_transitions.append(v)
+        
+        if(possible_transitions):
+            chosen_transition = random.randint(0, len(possible_transitions) - 1)
+            nextEvent = possible_transitions[chosen_transition]()
+            return nextEvent if nextEvent != "" else eventName
+        elif(self._state != self):
+            return self._state.handleEvent(eventName)
+        else:
+            return "STABLE"
 
 
 class Signature:

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -105,14 +105,13 @@ ${signature.Name} = Signature("${signature.Name}", "${signature.Multiplicity}", 
 # --- Conc States ---
 #macro(generateState $concState $padding)
 ${padding}class ${concState.getName()}_State(State):
+
 $padding     # substates
 	#foreach($substate in $concState.getSubstates())
 		#set($tab = "    ")
 		#set($newpadding = "$padding$tab")
 		#generateState($substate $newpadding)
 	#end
-
-$padding    """ The wrapper state for ${concState.getName()} """
 
 $padding    def __init__(self, context: State, root_context: State) -> None:
 $padding        super(${concState.getName()}, self).__init__(self) # init superclass
@@ -133,45 +132,79 @@ $padding        # state variable constraint assertions
 $padding        $init_constraint
 	#end
 
-
-$padding    class ${concState.getName()}(State):
-$padding        """ the concrete state that does the work """
-
-$padding        # transitions
+$padding    # transitions
        #foreach($trans in $concState.getTransitions())
-$padding        # trans - ${trans.getTransName()}
-$padding        def _trans_${trans.getTransName()}(self, is_event: bool) -> bool:
-$padding            r""" Execute a transition if possible
-$padding            :param is_event: is it triggered by event?
-$padding            :return: false to continue the loop in the executor
-$padding                     true to stop the loop
-$padding            """
-$padding            # TODO: global variables (signatures used in this state)
-$padding            #foreach($globalVar in $globalVariables)
-$padding            global ${globalVar}
-                    #end
+$padding    # trans - ${trans.getTransName()}
+$padding    def _trans_${trans.getTransName()}(self, is_event: bool) -> bool:
+$padding        r""" Execute a transition if possible
+$padding        :param is_event: is it triggered by event?
+$padding        :return: false to continue the loop in the executor
+$padding                 true to stop the loop
+$padding        """
+$padding        # TODO: global variables (signatures used in this state)
+$padding        #foreach($globalVar in $globalVariables)
+$padding        global ${globalVar}
+       #end
 
-$padding            if (is_event):
+$padding        if (is_event):
+$padding            return False
+$padding        else:
+$padding            logging.log(GCLOG, f" test guard condition of ${trans.getTransName()}.")
+$padding            # TODO: transition guard condition
+$padding            if not (${trans.getGuardCondition()}):
 $padding                return False
-$padding            else:
-$padding                logging.log(GCLOG, f" test guard condition of ${trans.getTransName()}.")
-$padding                # TODO: transition guard condition
-$padding                if not (${trans.getGuardCondition()}):
-$padding                    return False
 
-$padding            logging.log(ACLOG,f" action of [${trans.getTransName()}] triggered.")
-$padding            # TODO: transition action
-$padding            ${trans.getAction()}
+$padding        logging.log(ACLOG,f" action of [${trans.getTransName()}] triggered.")
+$padding        # TODO: transition action
+$padding        ${trans.getAction()}
 
-$padding            self._context.change_state(self._context.${trans.getFromStateName()}(self._context, self._root_context))
-$padding            return True
+$padding        self._context.change_state(self._context.${trans.getFromStateName()}(self._context, self._root_context))
+$padding        return True
 
         #end
-
 #end
 
 #foreach($concState in $concStateList)
 	#generateState($concState "")
 #end
+
+# --- Central Controller ---
+
+class CentralController:
+
+    def __init__(self):
+        self.concState = $!{rootState.getName()}_State()
+        self.possibleEvents = {#if(${allEvents.size()} > 0)"${allEvents.get(0).getName()}"#foreach($event in ${allEvents.subList(1, ${allEvents.size()})}), "$!{event.getName()}"#end#end}
+    
+    def run(self) -> None:
+        eventName = ""
+        # big step
+        while(eventName != "QUIT"):
+            eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
+
+       	    while(eventName == "help"):
+                for x in self.possibleEvents:
+                    print(x)
+                print("QUIT")
+
+                eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
+
+            if(eventName in self.possibleEvents):
+                # continue to process cascading events until the system is stable
+                while(true):
+                    new_event = self.concState.handleEvent(eventName)
+                    if(new_event != "STABLE"): 
+                        eventName = new_event
+                    else:
+                        break
+            elif(eventName != "QUIT"):
+                print("Invalid event name")
+            
+# --- Run the Model ---
+
+cc: CentralController = CentralController()
+cc.run()
+print("Terminating RapidDash Model")
+
 
 

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -14,7 +14,7 @@ CALOG = logging.DEBUG+3  # used for feedback on adding called
 logging.basicConfig(level=ACLOG)
 logging.addLevelName(GCLOG, "GUARD")
 logging.addLevelName(ACLOG, "ACTION")
-logging.addLevelName(CALOG, "CALLED")\
+logging.addLevelName(CALOG, "CALLED")
 
 # ===== Base Classes =====
 
@@ -62,6 +62,7 @@ class State(ABC):
             return "STABLE"
 
 
+#if($signatures)
 class Signature:
     name = "default_signature_name"
     _value = {}
@@ -111,79 +112,91 @@ class Signature:
     def __repr__(self):
         return f"{self.name} {self._value}"
 
+
 # --- Signatures ---
 
 #foreach($signature in $signatures)
 ${signature.Name} = Signature("${signature.Name}", "${signature.Multiplicity}", ${signature.Cardinality})
 #end
 
+#end
 # --- Conc States ---
 #macro(generateState $concState $padding)
 ${padding}class ${concState.getName()}_State(State):
 
-$padding    # substates
 	#foreach($substate in $concState.getSubstates())
 		#set($tab = "    ")
 		#set($newpadding = "$padding$tab")
+$padding    # substate
 		#generateState($substate $newpadding)
 	#end
-
 $padding    def __init__(self, context: State, root_context: State) -> None:
 $padding        super(${concState.getName()}_State, self).__init__(self) # init superclass
 $padding        self.change_state(root_context)  # go to default state
-$padding
+                #if($concState.getDecls())
+
 $padding        # state variable declarations
-	#foreach($decl in $concState.getDecls())
+	            #foreach($decl in $concState.getDecls())
 $padding        $decl
-	#end
+                #end#end
+                #if($concState.getInits())
 
 $padding        # state variable initializations
-	#foreach($init in $concState.getInits())
+	            #foreach($init in $concState.getInits())
 $padding        self.$init
-	#end
+                #end#end
+                #if($concState.getInitConstraints())
 
 $padding        # state variable constraint assertions
-	#foreach($init_constraint in $concState.getInitConstraints())
+                #foreach($init_constraint in $concState.getInitConstraints())
 $padding        $init_constraint
-	#end
+                #end#end
+                #if($concState.getTransitions())
 
 $padding        # initialize state transition dictionary
 $padding        self.transitions = dict()
-	#foreach($trans in $concState.getTransitions())
+	            #foreach($trans in $concState.getTransitions())
 $padding        self.transitions[self._trans_${trans.getTransName()}_guard] = self._trans_${trans.getTransName()}
-	#end
+                #end#end
 
+        #if($concState.getTransitions())
 $padding    # transitions
-       #foreach($trans in $concState.getTransitions())
+            #foreach($trans in $concState.getTransitions())
 $padding    # transition ${trans.getTransName()} guard function
 $padding    def _trans_${trans.getTransName()}_guard(self, current_event: str) -> bool:
-		#if(${trans.getEventCondition()} != "")
+		        #if(${trans.getEventCondition()})
 $padding        if(current_event != "${trans.getEventCondition()}"):
 $padding            return False
-		#end
-$padding        # if not (${trans.getGuardCondition()}):
-$padding            # return False  
+		        #end
+                #if($trans.getGuardCondition())
+$padding        if not (${trans.getGuardCondition()}):
+$padding            return False
+                #end
+$padding        logging.log(GCLOG,f"Guard of [${concState.getName()}_${trans.getTransName()}] triggered.")
 $padding        return True
 
 $padding    # transition ${trans.getTransName()} execution function
 $padding    def _trans_${trans.getTransName()}(self) -> str:
+                #if($globalVariables)
 $padding        # TODO: global variables (signatures used in this state)
-        #foreach($globalVar in $globalVariables)
+                #foreach($globalVar in $globalVariables)
 $padding        global ${globalVar}
-        #end
-$padding        logging.log(ACLOG,f" action of [${trans.getTransName()}] triggered.")
-$padding        # TODO: transition action
-$padding        # ${trans.getAction()}
+                #end#end
+$padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans.getTransName()}] triggered.")
+                #if($trans.getAction())
+$padding        ${trans.getAction()}
+                #end
 $padding        self._context.change_state(self._context.${trans.getFromStateName()}(self._context, self._root_context))
 $padding        return "${trans.getTriggerEvent()}"
 
+            #end
         #end
+
 #end
 
 #foreach($concState in $concStateList)
 	#generateState($concState "")
 #end
-
 # --- Central Controller ---
 
 class CentralController:
@@ -198,7 +211,7 @@ class CentralController:
         while(eventName != "QUIT"):
             eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
 
-       	    while(eventName == "help"):
+            while(eventName == "help"):
                 for x in self.possibleEvents:
                     print(x)
                 print("QUIT")
@@ -215,12 +228,10 @@ class CentralController:
                         break
             elif(eventName != "QUIT"):
                 print("Invalid event name")
-            
+
+
 # --- Run the Model ---
 
 cc: CentralController = CentralController()
 cc.run()
 print("Terminating RapidDash Model")
-
-
-

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -121,7 +121,7 @@ ${signature.Name} = Signature("${signature.Name}", "${signature.Multiplicity}", 
 #macro(generateState $concState $padding)
 ${padding}class ${concState.getName()}_State(State):
 
-$padding     # substates
+$padding    # substates
 	#foreach($substate in $concState.getSubstates())
 		#set($tab = "    ")
 		#set($newpadding = "$padding$tab")
@@ -129,7 +129,7 @@ $padding     # substates
 	#end
 
 $padding    def __init__(self, context: State, root_context: State) -> None:
-$padding        super(${concState.getName()}, self).__init__(self) # init superclass
+$padding        super({concState.getName()}_State, self).__init__(self) # init superclass
 $padding        self.change_state(root_context)  # go to default state
 $padding
 $padding        # state variable declarations
@@ -147,34 +147,35 @@ $padding        # state variable constraint assertions
 $padding        $init_constraint
 	#end
 
+$padding        # initialize state transition dictionary
+$padding        self.transitions = dict()
+	#foreach($trans in $concState.getTransitions())
+$padding        self.transitions[self._trans_${trans.getTransName()}_guard] = self._trans_${trans.getTransName()}
+	#end
+
 $padding    # transitions
        #foreach($trans in $concState.getTransitions())
-$padding    # trans - ${trans.getTransName()}
-$padding    def _trans_${trans.getTransName()}(self, is_event: bool) -> bool:
-$padding        r""" Execute a transition if possible
-$padding        :param is_event: is it triggered by event?
-$padding        :return: false to continue the loop in the executor
-$padding                 true to stop the loop
-$padding        """
-$padding        # TODO: global variables (signatures used in this state)
-$padding        #foreach($globalVar in $globalVariables)
-$padding        global ${globalVar}
-       #end
-
-$padding        if (is_event):
+$padding    # transition ${trans.getTransName()} guard function
+$padding    def _trans_${trans.getTransName()}_guard(self, current_event: str) -> bool:
+		#if(${trans.getEventCondition()} != "")
+$padding        if(current_event != "${trans.getEventCondition()}"):
 $padding            return False
-$padding        else:
-$padding            logging.log(GCLOG, f" test guard condition of ${trans.getTransName()}.")
-$padding            # TODO: transition guard condition
-$padding            if not (${trans.getGuardCondition()}):
-$padding                return False
+		#end
+$padding        # if not (${trans.getGuardCondition()}):
+$padding            # return False  
+$padding        return True
 
+$padding    # transition ${trans.getTransName()} execution function
+$padding    def _trans_${trans.getTransName()}(self) -> str:
+$padding        # TODO: global variables (signatures used in this state)
+        #foreach($globalVar in $globalVariables)
+$padding        global ${globalVar}
+        #end
 $padding        logging.log(ACLOG,f" action of [${trans.getTransName()}] triggered.")
 $padding        # TODO: transition action
-$padding        ${trans.getAction()}
-
+$padding        # ${trans.getAction()}
 $padding        self._context.change_state(self._context.${trans.getFromStateName()}(self._context, self._root_context))
-$padding        return True
+$padding        return "${trans.getTriggerEvent()}"
 
         #end
 #end
@@ -189,7 +190,7 @@ class CentralController:
 
     def __init__(self):
         self.concState = $!{rootState.getName()}_State()
-        self.possibleEvents = {#if(${allEvents.size()} > 0)"${allEvents.get(0).getName()}"#foreach($event in ${allEvents.subList(1, ${allEvents.size()})}), "$!{event.getName()}"#end#end}
+        self.possibleEvents = {#if(${allEvents.size()} > 0)"${allEvents.get(0).getModifiedName()}"#foreach($event in ${allEvents.subList(1, ${allEvents.size()})}), "$!{event.getModifiedName()}"#end#end}
     
     def run(self) -> None:
         eventName = ""
@@ -206,7 +207,7 @@ class CentralController:
 
             if(eventName in self.possibleEvents):
                 # continue to process cascading events until the system is stable
-                while(true):
+                while(True):
                     new_event = self.concState.handleEvent(eventName)
                     if(new_event != "STABLE"): 
                         eventName = new_event

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -11,7 +11,7 @@ GCLOG = logging.DEBUG+1  # used for guard condition
 ACLOG = logging.DEBUG+2  # used for action chosen
 CALOG = logging.DEBUG+3  # used for feedback on adding called
 
-logging.basicConfig(level=ACLOG)
+logging.basicConfig(level=logging.INFO)
 logging.addLevelName(GCLOG, "GUARD")
 logging.addLevelName(ACLOG, "ACTION")
 logging.addLevelName(CALOG, "CALLED")
@@ -32,7 +32,7 @@ class State(ABC):
             self._set_parent_state(args[0])
 
     def __repr__(self):
-        return f"State {self.__class__.__name__}"
+        return f"{self.__class__.__name__}"
 
     def _set_parent_state(self, state: State):
         self._parent_state = state
@@ -41,23 +41,31 @@ class State(ABC):
         self._root_state = state
 
     def change_state(self, state: State):
-        logging.info(f"{self._state} => {state}")
+        if(self._state is not None):
+            logging.info(f"{self._state} => {state}")
         self._state = state
-        
-    def handleEvent(self, eventName: str):
+
+    def __eq__(self, obj):
+        return type(self) == type(obj)
+
+    def __ne__(self, obj):
+        return type(self) != type(obj)
+
+    def handleEvent(self, eventName: str, vistedStates: set):
+        vistedStates.add(type(self._state))
         possible_transitions = []
         for k, v in self.transitions.items():
             if k(eventName):
                 possible_transitions.append(v)
-        
+
         if(possible_transitions):
             chosen_transition = random.randint(0, len(possible_transitions) - 1)
             nextEvent = possible_transitions[chosen_transition]()
-            return nextEvent if nextEvent != "" else eventName
+            return nextEvent if (type(self._state) not in vistedStates) else ""
         elif(self._state != self):
-            return self._state.handleEvent(eventName)
+            return self._state.handleEvent(eventName, vistedStates)
         else:
-            return "STABLE"
+            return ""
 
 
 #if($signatures)
@@ -130,16 +138,16 @@ $padding    # substate(s)
 	#end
 $padding    def __init__(self, parent_state: State, root_state: State) -> None:
 	#if(${padding} == "")
-$padding        super(${concState.getName()}_State, self).__init__(self, None, self) # init superclass
-	#else
-$padding        super(parent_state.${concState.getName()}_State, self).__init__(self, parent_state, root_state) # init superclass
-	#end
-    #if($concState.getSubstates())
-$padding        self.change_state(self.${concState.getSubstates().get(0).getName()}_State(self, root_state))  # go to default state 
+$padding        super(${concState.getName()}_State, self).__init__(None, self) # init superclass
+$padding        self.change_state(self.${concState.getSubstates().get(0).getName()}_State(self, self))  # This is a root state
     #else
+$padding        super(parent_state.${concState.getName()}_State, self).__init__(parent_state, root_state) # init superclass
+        #if($concState.getSubstates())
+$padding        self.change_state(self.${concState.getSubstates().get(0).getName()}_State(self, root_state))  # go to default state
+        #else
 $padding        self.change_state(self)  # go to default state
-    #end
-
+        #end
+	#end
                 #if($concState.getDecls())
 
 $padding        # state variable declarations
@@ -192,7 +200,7 @@ $padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans
                 #if($trans.getAction())
 $padding        ${trans.getAction()}
                 #end
-$padding        self._parent_state.change_state(self._parent_state.${trans.getFromStateName()}_State(self._parent_state, self._root_state))
+$padding        self._parent_state.change_state(self._parent_state.${trans.getToStateName()}_State(self._parent_state, self._root_state))
 $padding        return "${trans.getTriggerEvent()}"
 
             #end
@@ -226,9 +234,10 @@ class CentralController:
 
             if(eventName in self.possibleEvents):
                 # continue to process cascading events until the system is stable
+                vistedStates = set()
                 while(True):
-                    new_event = self.concState.handleEvent(eventName)
-                    if(new_event != "STABLE"): 
+                    new_event = self.concState.handleEvent(eventName, vistedStates)
+                    if(new_event != ""):
                         eventName = new_event
                     else:
                         break

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -19,28 +19,26 @@ logging.addLevelName(CALOG, "CALLED")
 # ===== Base Classes =====
 
 class State(ABC):
-    """" State base class """
 
     def __init__(self, *args) -> None:
-        """
-        State() => doesn't do anything
-        State(context: State) => set _context to context
-        State(context: State, root_context: State) => also set root context
-        """
-
+        # State() => doesn't do anything
+        # State(parent_state: State) => set _parent_state
+        # State(parent_state: State, root_state: State) => also set _root_state
+        self._state = None
+        self.transitions = dict()
         if len(args) >= 2 and isinstance(args[1], State):
-            self._set_root_context(args[1])
+            self._set_root_state(args[1])
         if len(args) >= 1 and isinstance(args[0], State):
-            self._set_context(args[0])
+            self._set_parent_state(args[0])
 
     def __repr__(self):
         return f"State {self.__class__.__name__}"
 
-    def _set_context(self, context: State):
-        self._context = context
+    def _set_parent_state(self, state: State):
+        self._parent_state = state
 
-    def _set_root_context(self, context: State):
-        self._root_context = context
+    def _set_root_state(self, state: State):
+        self._root_state = state
 
     def change_state(self, state: State):
         logging.info(f"{self._state} => {state}")
@@ -127,12 +125,21 @@ ${padding}class ${concState.getName()}_State(State):
 	#foreach($substate in $concState.getSubstates())
 		#set($tab = "    ")
 		#set($newpadding = "$padding$tab")
-$padding    # substate
+$padding    # substate(s)
 		#generateState($substate $newpadding)
 	#end
-$padding    def __init__(self, context: State, root_context: State) -> None:
-$padding        super(${concState.getName()}_State, self).__init__(self) # init superclass
-$padding        self.change_state(root_context)  # go to default state
+$padding    def __init__(self, parent_state: State, root_state: State) -> None:
+	#if(${padding} == "")
+$padding        super(${concState.getName()}_State, self).__init__(self, None, self) # init superclass
+	#else
+$padding        super(parent_state.${concState.getName()}_State, self).__init__(self, parent_state, root_state) # init superclass
+	#end
+    #if($concState.getSubstates())
+$padding        self.change_state(self.${concState.getSubstates().get(0).getName()}_State(self, root_state))  # go to default state 
+    #else
+$padding        self.change_state(self)  # go to default state
+    #end
+
                 #if($concState.getDecls())
 
 $padding        # state variable declarations
@@ -154,7 +161,6 @@ $padding        $init_constraint
                 #if($concState.getTransitions())
 
 $padding        # initialize state transition dictionary
-$padding        self.transitions = dict()
 	            #foreach($trans in $concState.getTransitions())
 $padding        self.transitions[self._trans_${trans.getTransName()}_guard] = self._trans_${trans.getTransName()}
                 #end#end
@@ -186,7 +192,7 @@ $padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans
                 #if($trans.getAction())
 $padding        ${trans.getAction()}
                 #end
-$padding        self._context.change_state(self._context.${trans.getFromStateName()}(self._context, self._root_context))
+$padding        self._parent_state.change_state(self._parent_state.${trans.getFromStateName()}_State(self._parent_state, self._root_state))
 $padding        return "${trans.getTriggerEvent()}"
 
             #end
@@ -202,7 +208,7 @@ $padding        return "${trans.getTriggerEvent()}"
 class CentralController:
 
     def __init__(self):
-        self.concState = $!{rootState.getName()}_State()
+        self.concState = $!{rootState.getName()}_State(None, None)
         self.possibleEvents = {#if(${allEvents.size()} > 0)"${allEvents.get(0).getModifiedName()}"#foreach($event in ${allEvents.subList(1, ${allEvents.size()})}), "$!{event.getModifiedName()}"#end#end}
     
     def run(self) -> None:

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -129,7 +129,7 @@ $padding    # substates
 	#end
 
 $padding    def __init__(self, context: State, root_context: State) -> None:
-$padding        super({concState.getName()}_State, self).__init__(self) # init superclass
+$padding        super(${concState.getName()}_State, self).__init__(self) # init superclass
 $padding        self.change_state(root_context)  # go to default state
 $padding
 $padding        # state variable declarations

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -60,8 +60,8 @@ public class DashPythonTranslation {
     		this.parent = parent;
     	}
     	
-    	public String getName() {
-    		return name;
+    	public String getModifiedName() {
+    		return modifiedName;
     	}
     }
 
@@ -88,7 +88,6 @@ public class DashPythonTranslation {
         for(String stateName: dashModule.states.keySet()){
             this.concStateMap.put(stateName, new State(stateName));
         }
-        
         
         for(DashConcState state: dashModule.concStates.values()) {
         	if(rootState == null) {
@@ -145,7 +144,6 @@ public class DashPythonTranslation {
         
         // add substates to dash states
         for(DashState state: dashModule.states.values()) {
-        	System.out.println(state);
         	for(DashState substate: state.states) {
         		this.concStateMap.get(state.modifiedName).addSubstate(this.concStateMap.get(substate.modifiedName));
         		this.concStateMap.get(substate.modifiedName).parent = concStateMap.get(state.modifiedName);
@@ -228,8 +226,8 @@ public class DashPythonTranslation {
         private String transName;                       // transition name
         private String action;                          // the logic for this transition to be executed
         private String guardCondition;                  // the guard condition of this transition
-        private String eventCondition;
-        private String triggerEvent;
+        private String eventCondition = "";
+        private String triggerEvent = "";
         private String transTemplate;
 
         public Transition(DashTrans dashTrans){
@@ -247,8 +245,7 @@ public class DashPythonTranslation {
                 this.fromStateName = dashTrans.fromExpr.fromExpr.get(0);
             }
             if(dashTrans.onExpr != null){      // determines the trigger event
-                // TODO: event related
-                this.eventCondition = "pass\t# <placeholder for Event>";
+                this.eventCondition = dashTrans.onExpr.name;
             }
             if(dashTrans.whenExpr != null){    // determines the guard_condition (if statement)
                 // TODO: need to be able to translate the predicates first
@@ -268,7 +265,7 @@ public class DashPythonTranslation {
                 this.toStateName = dashTrans.gotoExpr.toString();
             }
             if(dashTrans.sendExpr != null){    // determines the event to send
-                this.triggerEvent = "pass\t# <placeholder for Triggering event>";
+                this.triggerEvent = dashTrans.sendExpr.name;
             }
             if(dashTrans.transTemplate != null){   // TODO: don't know what this does
                 this.transTemplate = "pass\t# <placeholder for Trans Template>";

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -247,21 +247,19 @@ public class DashPythonTranslation {
                 this.eventCondition = dashTrans.onExpr.name;
             }
             if(dashTrans.whenExpr != null){    // determines the guard_condition (if statement)
-                // TODO: need to be able to translate the predicates first
                 DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.whenExpr);
 
                 // set condition
                 this.guardCondition = dashExprTranslator.toString();
             }
             if(dashTrans.doExpr != null){      // determines the action
-                // TODO: need to be able to translate the actions first
                 DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.doExpr);
 
                 // set action
                 this.action = dashExprTranslator.toString();
             }
             if(dashTrans.gotoExpr != null){    // determine the next state
-                this.toStateName = dashTrans.gotoExpr.toString();
+                this.toStateName = dashTrans.gotoExpr.gotoExpr.get(0);
             }
             if(dashTrans.sendExpr != null){    // determines the event to send
                 this.triggerEvent = dashTrans.sendExpr.name;

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -221,14 +221,14 @@ public class DashPythonTranslation {
     public class Transition{
         private String stateName;                       // state name
 
-        private String fromStateName;
-        private String toStateName;
-        private String transName;                       // transition name
-        private String action;                          // the logic for this transition to be executed
-        private String guardCondition;                  // the guard condition of this transition
+        private String fromStateName = "";
+        private String toStateName = "";
+        private String transName = "";                       // transition name
+        private String action = "";                          // the logic for this transition to be executed
+        private String guardCondition = "";                  // the guard condition of this transition
         private String eventCondition = "";
         private String triggerEvent = "";
-        private String transTemplate;
+        private String transTemplate = "";
 
         public Transition(DashTrans dashTrans){
             // set default transition information
@@ -238,7 +238,6 @@ public class DashPythonTranslation {
             } else {
                 this.stateName = ((DashState)dashTrans.parentState).modifiedName;
             }
-            // System.out.println("[Debug]: transition: " + dashTrans.name + ", state name: " + this.stateName);
 
             // check keywords
             if(dashTrans.fromExpr != null){    // determines which state this transition belongs to

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -1,6 +1,7 @@
 package ca.uwaterloo.watform.rapidDash;
 
 import ca.uwaterloo.watform.ast.DashConcState;
+import ca.uwaterloo.watform.ast.DashEvent;
 import ca.uwaterloo.watform.ast.DashState;
 import ca.uwaterloo.watform.ast.DashTrans;
 import ca.uwaterloo.watform.ast.DashInit;
@@ -26,7 +27,8 @@ public class DashPythonTranslation {
     private DashModule dashModule;
 
     public List<Signature> signatures;
-
+    public List<Event> allEvents;
+    public State rootState = null;
     private Map<String, State> concStateMap;
 
     public class Signature {
@@ -44,6 +46,24 @@ public class DashPythonTranslation {
         public String getMultiplicity() { return multiplicity; }
         public int getCardinality() { return cardinality; }
     }
+    
+    public class Event {
+    	private String name;
+    	private String modifiedName;
+    	private String type; // env event vs event
+    	private State parent;
+    	
+    	public Event(String name, String modifiedName, String type, State parent) {
+    		this.name = name;
+    		this.modifiedName = modifiedName;
+    		this.type = type;
+    		this.parent = parent;
+    	}
+    	
+    	public String getName() {
+    		return name;
+    	}
+    }
 
     /**
      * Constructs a new DashPythonTranslation object
@@ -56,10 +76,12 @@ public class DashPythonTranslation {
         this.signatures = dashModule.sigs.values().stream()
                 .map(sig -> new Signature(clean(sig.label), getMultiplicity(sig), getCardinality(sig)))
                 .collect(Collectors.toList());
+        
+        this.allEvents = new ArrayList<Event>();
 
         // get state hierarchy
         this.concStateMap = new HashMap<>();
-        // initialize all states instances, TODO: state will have more member variables, here is only used for transitions
+        // initialize all states instances
         for(String stateName: dashModule.concStates.keySet()){
             this.concStateMap.put(stateName, new State(stateName));
         }
@@ -69,6 +91,9 @@ public class DashPythonTranslation {
         
         
         for(DashConcState state: dashModule.concStates.values()) {
+        	if(rootState == null) {
+        		rootState = this.concStateMap.get(state.modifiedName);
+        	}
         	// add state variable declarations (decls)
         	for(Decl decl: state.decls) {
         		DashExprToPython dashExprTranslator = new DashExprToPython<>(decl.expr);
@@ -100,6 +125,13 @@ public class DashPythonTranslation {
         		}
         	}
         	
+        	// add state events
+        	for(DashEvent event: state.events) {
+        		Event newEvent = new Event(event.name, event.modifiedName, event.type, this.concStateMap.get(state.modifiedName));
+        		this.concStateMap.get(newEvent);
+        		allEvents.add(newEvent);
+        	}
+        	     	
         	// add substates to conc states
         	for(DashConcState substate: state.concStates) {
         		this.concStateMap.get(state.modifiedName).addSubstate(this.concStateMap.get(substate.modifiedName));
@@ -161,6 +193,7 @@ public class DashPythonTranslation {
         private List<String> decls;
         private List<String> inits;
         private List<String> init_constraints;
+        private List<Event> events;
         public State parent = null;
         public State(String stateName){
             this.stateName = stateName;
@@ -179,10 +212,12 @@ public class DashPythonTranslation {
         public List<String> getDecls() { return decls.stream().collect(Collectors.toList()); }
         public List<String> getInits() { return inits.stream().collect(Collectors.toList()); }
         public List<String> getInitConstraints() { return init_constraints.stream().collect(Collectors.toList()); }
+        public List<Event> getEvents() { return events.stream().collect(Collectors.toList()); }
         public void addSubstate(State s) { substates.add(s); }
         public void addDecl(String s) { decls.add(s); }
         public void addInit(String s) { inits.add(s); }
         public void addInitConstraint(String s) { init_constraints.add(s); }
+        public void addEvent(Event e) { events.add(e); }
     }
 
     public class Transition{

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
@@ -54,6 +54,11 @@ public class CoreDashToPython {
 
         // add concurrent states
         vc.put("concStateList", dashPythonTranslation.getStates());
+        
+        // add events
+        vc.put("allEvents", dashPythonTranslation.allEvents);
+        
+        vc.put("rootState", dashPythonTranslation.rootState);
 
         // print modified template file
         StringWriter sw = new StringWriter();


### PR DESCRIPTION
This PR:
- adds the central controller to the python model. This controller prompts users for events and contains a help command to list all possible events.
- splits transitions into two functions: a guard function that checks if a transition can be taken and another that actually executes the transitions 
- implements transition onExpr (in transition guard function)
- implements transition sendExpr (return value of transition execution function)
- adds a handleExpression function to the state class
- adds a dictionary to each state that maps guard transition functions to transition execution functions (which is used in handleExpression)

See linked Asana tickets for a more in-depth description and sample input/output

TODO:
- is there a need to differentiate between env events and regular events? (maybe ask Prof Day)
- add relevant test cases to test files

Ticket links:
https://app.asana.com/0/1200958948599566/1202460837475461/f
https://app.asana.com/0/1200958948599566/1202309691137488/f