### PR TITLE
Add translation for signature subset relationships

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -15,7 +15,7 @@ SVLOG = logging.DEBUG+4  # used for signature validity check
 logging.basicConfig(level=logging.INFO)
 logging.addLevelName(GCLOG, "GUARD")
 logging.addLevelName(ACLOG, "ACTION")
-logging.addLevelName(CALOG, "CALLED
+logging.addLevelName(CALOG, "CALLED")
 logging.addLevelName(SVLOG, "SIG")
 
 # ===== Base Classes =====
@@ -205,7 +205,6 @@ class Signature:
     def __repr__(self):
         return f"{self.name} {self.get_value()}"
 
-
 # --- Signatures ---
 
 #foreach($signature in $signatures)
@@ -218,7 +217,7 @@ for sig in signatures:
     if not sig.check_validity(sig.get_value()):
         raise Exception("Invalid initial value for signature: " + sig.name)
     print(sig)
-
+#end
 
 # --- Conc States ---
 #macro(generateState $concState $padding)

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -10,7 +10,7 @@ from abc import ABC
 GCLOG = logging.DEBUG+1  # used for guard condition
 ACLOG = logging.DEBUG+2  # used for action chosen
 CALOG = logging.DEBUG+3  # used for feedback on adding called
-SVLOG = logging.DEBUG + 4  # used for signature validity check
+SVLOG = logging.DEBUG+4  # used for signature validity check
 
 logging.basicConfig(level=ACLOG)
 logging.addLevelName(GCLOG, "GUARD")
@@ -50,18 +50,6 @@ class State(ABC):
 
 
 class Signature:
-    name = "default_signature_name"
-    _value = {}
-    lower = 0
-    upper = None
-
-    isSubset = False
-    parents = set()
-
-    isSubsig = False
-    parent = None
-    isAbstract = False
-
     def __init__(self, name, multiplicity=None, cardinality=1, isSubset=False, parents=None, isSubsig=False,
                  parent=None, isAbstract=False):
         """
@@ -77,14 +65,16 @@ class Signature:
         :param set[Signature] parents: The union of signatures this signature is subset of, declared with "in"
         :param bool isSubsig: If the signature is declared with keyword "extends"
         :param Signature parent: The signature this signature is disjoint subset of, declared with "extends"
-        :param bool isAbstract: If the signature is declared with keyword "extends"
+        :param bool isAbstract: If the signature is declared with keyword "abstract"
 
-        :param priority: The priority of the message, can be a number 1-5
-        :raises ValueError: if the message_body exceeds 160 characters
-        :raises TypeError: if the message_body is not a basestring
+        :raises Exception: If the input cardinality is invalid
         """
+        self._value = {}
+        self.lower = 0
+        self.upper = None
+
         if parents is None:
-            parents = set()
+            parents = {}
 
         self.name = name
         if not multiplicity:

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -10,11 +10,13 @@ from abc import ABC
 GCLOG = logging.DEBUG+1  # used for guard condition
 ACLOG = logging.DEBUG+2  # used for action chosen
 CALOG = logging.DEBUG+3  # used for feedback on adding called
+SVLOG = logging.DEBUG + 4  # used for signature validity check
 
 logging.basicConfig(level=ACLOG)
 logging.addLevelName(GCLOG, "GUARD")
 logging.addLevelName(ACLOG, "ACTION")
-logging.addLevelName(CALOG, "CALLED")\
+logging.addLevelName(CALOG, "CALLED")
+logging.addLevelName(SVLOG, "SIG")
 
 # ===== Base Classes =====
 
@@ -50,8 +52,40 @@ class State(ABC):
 class Signature:
     name = "default_signature_name"
     _value = {}
+    lower = 0
+    upper = None
 
-    def __init__(self, name, multiplicity=None, cardinality=1):
+    isSubset = False
+    parents = set()
+
+    isSubsig = False
+    parent = None
+    isAbstract = False
+
+    def __init__(self, name, multiplicity=None, cardinality=1, isSubset=False, parents=None, isSubsig=False,
+                 parent=None, isAbstract=False):
+        """
+        Initialize a Signature object. For abstract signatures, the cardinality denotes the number of additional atoms
+        other than the atoms contained in its subsigs.
+
+        :param str name: The signature's name
+        :param int multiplicity: The multiplicity keyword, can be one of "one", "some", "lone" and "set". Default to be
+        "set"
+        :param int cardinality: The number of atoms in the signature. If the signature is abstract, then this is the
+        number of additional atoms other than the atoms contained in its subsigs
+        :param bool isSubset: If the signature is declared with keyword "in"
+        :param set[Signature] parents: The union of signatures this signature is subset of, declared with "in"
+        :param bool isSubsig: If the signature is declared with keyword "extends"
+        :param Signature parent: The signature this signature is disjoint subset of, declared with "extends"
+        :param bool isAbstract: If the signature is declared with keyword "extends"
+
+        :param priority: The priority of the message, can be a number 1-5
+        :raises ValueError: if the message_body exceeds 160 characters
+        :raises TypeError: if the message_body is not a basestring
+        """
+        if parents is None:
+            parents = set()
+
         self.name = name
         if not multiplicity:
             self.lower = 0
@@ -68,39 +102,109 @@ class Signature:
         elif multiplicity == "set":
             self.lower = 0
             self.upper = None
+
+        # Subset
+        self.isSubset = isSubset
+        self.parents = parents
+        self.subsets = set()
+        for p in self.parents:
+            p.subsets.add(self)
+
+        # Subsig
+        self.isSubsig = isSubsig
+        self.parent = parent
+        self.subsigs = set()
+        if self.parent:
+            self.parent.subsigs.add(self)
+        self.isAbstract = isAbstract
+
+        if not self.isSubset:
+            value = {name + str(i + 1) for i in range(cardinality)}
         else:
-            self.lower = 0
-            self.upper = None
-        value = {name + str(i + 1) for i in range(cardinality)}
-        if self.set_value(value) is None:
-            raise Exception("Invalid initial value for signature: " + name)
+            superset = [v for parent in self.parents for v in parent.get_value()]
+            if len(superset) < cardinality:
+                raise Exception("Invalid cardinality for subset signature: " + name)
+            value = set(superset[:cardinality])
+
+        self.set_value_no_constraints(value)
 
     def check_validity(self, value) -> bool:
         assert isinstance(value, set), "Signature has to be a set"
-        if self.upper:
-            return self.lower <= len(value) <= self.upper
-        else:
-            return self.lower <= len(value)
+        # Subset
+        if self.isSubset:
+            superset = [v for parent in self.parents for v in parent.get_value()]
+            if not value.issubset(superset):
+                logging.log(SVLOG, self.name + " is not a valid subset.")
+                return False
+        if self.subsets:
+            value_copy = self._value
+            self.set_value_no_constraints(value)
+            for subset in self.subsets:
+                if not subset.check_validity(subset.get_value()):
+                    logging.log(SVLOG, self.name + "'s subsets are no longer valid subsets.")
+                    return False
+            self._value = value_copy
+
+        # Subsig
+        if self.subsigs:
+            subset = set([v for subsig in self.subsigs for v in subsig.get_value()])
+            if not subset.issubset(value):
+                logging.log(SVLOG, self.name + " does not contain all the atoms in its subsigs.")
+                return False
+            if self.isAbstract and not len(subset) == len(value):
+                logging.log(SVLOG, self.name + " does not conform to the abstract constraint.")
+                return False
+        if self.isSubsig:
+            siblings = [v for subsig in self.parent.subsigs - {self} for v in subsig.get_value()]
+            if len(value.intersection(siblings)) != 0:
+                logging.log(SVLOG, self.name + " is not a disjoint subset of " + self.parent.name + ".")
+                return False
+            if not self.parent.check_validity(self.parent.get_value()):
+                logging.log(SVLOG, self.name + "'s parent " + self.parent.name + " does not have valid value.")
+                return False
+
+        # Multiplicity
+        if (self.upper and len(value) > self.upper) or self.lower > len(value):
+            logging.log(SVLOG, self.name + " violates the multiplicity rule.")
+            return False
+
+        return True
 
     def get_value(self):
+        if self.subsigs:
+            subset = set([v for subsig in self.subsigs for v in subsig.get_value()])
+            return subset.union(self._value)
         return self._value
 
     # Returns None if the value intended to be set is invalid
     def set_value(self, value):
         if self.check_validity(value):
-            self._value = value
+            subset = set([v for subsig in self.subsigs for v in subsig.get_value()])
+            self._value = value - subset
             return self._value
         else:
             return None
 
+    def set_value_no_constraints(self, value):
+        subset = set([v for subsig in self.subsigs for v in subsig.get_value()])
+        self._value = value - subset
+        return self._value
+
     def __repr__(self):
-        return f"{self.name} {self._value}"
+        return f"{self.name} {self.get_value()}"
 
 # --- Signatures ---
 
 #foreach($signature in $signatures)
-${signature.Name} = Signature("${signature.Name}", "${signature.Multiplicity}", ${signature.Cardinality})
+${signature.Name} = Signature("${signature.Name}", "${signature.Multiplicity}", ${signature.Cardinality}, ${signature.IsSubset}, ${signature.Parents}, ${signature.IsSubsig}, ${signature.Parent}, ${signature.IsAbstract})
 #end
+
+signatures = ${signaturesList}
+for sig in signatures:
+    if not sig.check_validity(sig.get_value()):
+        raise Exception("Invalid initial value for signature: " + sig.name)
+    print(sig)
+
 
 # --- Conc States ---
 #macro(generateState $concState $padding)

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -102,7 +102,7 @@ public class DashPythonTranslationTest {
     }
 
     @Test
-    public void testSignatures() throws Exception {
+    public void testSignaturesMultiplicity() throws Exception {
         String dashModel = "sig Floor {}\n" +
                 "one sig Chicken {}\n" +
                 "some sig SomeSig {}\n" +
@@ -127,6 +127,41 @@ public class DashPythonTranslationTest {
         assertEquals(translation.signatures.get(3).multiplicity, "lone");
         assertEquals(translation.signatures.get(3).cardinality, 1);
     }
+
+    @Test
+    public void testSignaturesSubsetRelationships() throws Exception {
+        String dashModel = "abstract sig A {}\n" +
+                "sig B {}\n" +
+                "sig C in A + B {}\n" +
+                "sig D in C + A {}\n" +
+                "sig AA extends A {}\n" +
+                "sig AAA extends AA {}";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        DashToCoreDash.transformToCoreDash(dashModule);
+
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule);
+
+        assertEquals(6, translation.signatures.size());
+        assertEquals(translation.signatures.get(0).name, "A");
+        assertEquals(translation.signatures.get(0).cardinality, 0);
+        assertEquals(translation.signatures.get(1).name, "B");
+        assertEquals(translation.signatures.get(1).isSubset, false);
+        assertEquals(translation.signatures.get(1).parents.size(), 0);
+        assertEquals(translation.signatures.get(2).name, "C");
+        assertEquals(translation.signatures.get(2).isSubset, true);
+        assertEquals(translation.signatures.get(2).parents, Arrays.asList("A", "B"));
+        assertEquals(translation.signatures.get(3).name, "D");
+        assertEquals(translation.signatures.get(3).isSubset, true);
+        assertEquals(translation.signatures.get(3).parents, Arrays.asList("C", "A"));
+        assertEquals(translation.signatures.get(4).name, "AA");
+        assertEquals(translation.signatures.get(4).isSubsig, true);
+        assertEquals(translation.signatures.get(4).parent, "A");
+        assertEquals(translation.signatures.get(5).name, "AAA");
+        assertEquals(translation.signatures.get(5).isSubsig, true);
+        assertEquals(translation.signatures.get(5).parent, "AA");
+    }
+
 
     @Test
     public void testWhenExpr_1() throws Exception {

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -26,7 +26,7 @@ public class CoreDashToPythonTest {
     }
 
     @Test
-    public void testSignatures() throws IOException {
+    public void testSignaturesMultiplicity() throws IOException {
         String dashModel = "sig Floor {}\n" +
                 "sig Medication {}\n" +
                 "one sig Chicken, Farmer, Fox, Grain {}\n" +
@@ -36,14 +36,42 @@ public class CoreDashToPythonTest {
         DashToCoreDash.transformToCoreDash(dashModule);
         DashPythonTranslation translation = new DashPythonTranslation(dashModule);
 
-        List<String> expectedTranslation = Arrays.asList("Floor = Signature(\"Floor\", \"set\", 3)",
-                "Medication = Signature(\"Medication\", \"set\", 3)",
-                "Chicken = Signature(\"Chicken\", \"one\", 1)",
-                "Farmer = Signature(\"Farmer\", \"one\", 1)",
-                "Fox = Signature(\"Fox\", \"one\", 1)",
-                "Grain = Signature(\"Grain\", \"one\", 1)",
-                "SomeSig = Signature(\"SomeSig\", \"some\", 3)",
-                "LoneSig = Signature(\"LoneSig\", \"lone\", 1)");
+        List<String> expectedTranslation = Arrays.asList("Floor = Signature(\"Floor\", \"set\", 3, False, {}, False, None, False)\n",
+                "Medication = Signature(\"Medication\", \"set\", 3, False, {}, False, None, False)\n",
+                "Chicken = Signature(\"Chicken\", \"one\", 1, False, {}, False, None, False)\n",
+                "Farmer = Signature(\"Farmer\", \"one\", 1, False, {}, False, None, False)\n",
+                "Fox = Signature(\"Fox\", \"one\", 1, False, {}, False, None, False)\n",
+                "Grain = Signature(\"Grain\", \"one\", 1, False, {}, False, None, False)\n",
+                "SomeSig = Signature(\"SomeSig\", \"some\", 3, False, {}, False, None, False)\n",
+                "LoneSig = Signature(\"LoneSig\", \"lone\", 1, False, {}, False, None, False)");
+
+        for(String sigTrans : expectedTranslation){
+            assert (CoreDashToPython.convert2String(translation).contains(sigTrans));
+        }
+    }
+
+    @Test
+    public void testSignaturesSubsetsRelationship() throws IOException {
+        String dashModel = "sig Asubset1, Asubset2 extends A {}\n" +
+        "sig AAsubset1 extends Asubset1 {}\n" +
+        "sig C in A + B {}\n" +
+        "sig D in C + A {}\n" +
+        "sig E extends A {}\n" +
+        "sig A {}\n" +
+        "sig B {}\n";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        DashToCoreDash.transformToCoreDash(dashModule);
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule);
+
+        List<String> expectedTranslation = Arrays.asList("A = Signature(\"A\", \"set\", 3, False, {}, False, None, False)",
+                "Asubset1 = Signature(\"Asubset1\", \"set\", 3, False, {}, True, A, False)",
+                "Asubset2 = Signature(\"Asubset2\", \"set\", 3, False, {}, True, A, False)",
+                "AAsubset1 = Signature(\"AAsubset1\", \"set\", 3, False, {}, True, Asubset1, False)",
+                "E = Signature(\"E\", \"set\", 3, False, {}, True, A, False)",
+                "B = Signature(\"B\", \"set\", 3, False, {}, False, None, False)",
+                "C = Signature(\"C\", \"set\", 3, True, {A,B}, False, None, False)",
+                "D = Signature(\"D\", \"set\", 3, True, {C,A}, False, None, False)");
 
         for(String sigTrans : expectedTranslation){
             assert (CoreDashToPython.convert2String(translation).contains(sigTrans));

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -16,6 +16,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static edu.mit.csail.sdg.alloy4.TableView.clean;
+import edu.mit.csail.sdg.alloy4.ConstList;
 
 /**
  * Mutable; this class represents an Dash to Python translation module
@@ -33,16 +34,50 @@ public class DashPythonTranslation {
         public String name;
         public String multiplicity;
         public int cardinality;
+        public boolean isSubset;
+        public List<String> parents;
+        public boolean isSubsig;
+        public String parent;
+        public boolean isAbstract;
 
-        public Signature(String name, String multiplicity, int cardinality) {
+        public Signature(String name, String multiplicity, int cardinality, boolean isSubset, List<String> parents
+                , boolean isSubsig, String parent, boolean isAbstract) {
             this.name = name;
             this.multiplicity = multiplicity;
             this.cardinality = cardinality;
+            this.isSubset = isSubset;
+            this.parents = parents;
+            this.isSubsig = isSubsig;
+            this.parent = parent;
+            this.isAbstract = isAbstract;
         }
 
         public String getName() { return name; }
         public String getMultiplicity() { return multiplicity; }
         public int getCardinality() { return cardinality; }
+        public String getIsSubset() {
+            if (this.isSubset)
+                return "True";
+            return "False";
+        }
+        public String getParents() {
+            return "{" + String.join(",", this.parents) + "}";
+        }
+        public String getIsSubsig() {
+            if (this.isSubsig)
+                return "True";
+            return "False";
+        }
+        public String getParent() {
+            if (this.parent != null)
+                return this.parent;
+            return "None";
+        }
+        public String getIsAbstract() {
+            if (this.isAbstract)
+                return "True";
+            return "False";
+        }
     }
 
     /**
@@ -52,9 +87,51 @@ public class DashPythonTranslation {
     public DashPythonTranslation(DashModule dashModule) {
         this.dashModule = dashModule;
 
+        // Sort the signatures based on dependencies
+        // TODO may need topological sort later to improve performance
+        // I am using a not efficient starightforward sorting algorithm for now
+        ArrayList<Sig> signaturesOriginalList = new ArrayList<Sig>(dashModule.sigs.values());
+        ArrayList<Sig> signaturesSortedList = new ArrayList<Sig>();
+        ArrayList<String> covered = new ArrayList<String>();
+        while (signaturesOriginalList.size() != 0) {
+            for (Sig sig : signaturesOriginalList){
+                if (sig.isSubsig != null) {
+                    if (((Sig.PrimSig) sig).parent == Sig.UNIV || covered.contains(clean(((Sig.PrimSig) sig).parent.label))) {
+                        signaturesSortedList.add(sig);
+                        signaturesOriginalList.remove(sig);
+                        covered.add(clean(sig.label));
+                        break;
+                    }
+                }
+                if (sig.isSubset != null) {
+                    ArrayList<String> parentsList = new ArrayList<String>();
+                    for (Sig p : ((Sig.SubsetSig) sig).parents)
+                        parentsList.add(clean(p.label));
+                    if (covered.containsAll(parentsList)) {
+                        signaturesSortedList.add(sig);
+                        signaturesOriginalList.remove(sig);
+                        covered.add(clean(sig.label));
+                        break;
+                    }
+                }
+            }
+
+        }
+
         // get signature names
-        this.signatures = dashModule.sigs.values().stream()
-                .map(sig -> new Signature(clean(sig.label), getMultiplicity(sig), getCardinality(sig)))
+        this.signatures = signaturesSortedList.stream()
+                .map(sig -> {
+                    List<String> parents = new ArrayList<String>();
+                    if (sig.isSubset != null)
+                        for (Sig p : ((Sig.SubsetSig) sig).parents)
+                            parents.add(clean(p.label));
+                    boolean isSubsig = sig.isSubsig != null && ((Sig.PrimSig) sig).parent != Sig.UNIV;
+                    String parent = null;
+                    if (isSubsig)
+                        parent = clean(((Sig.PrimSig) sig).parent.label);
+                    return new Signature(clean(sig.label), getMultiplicity(sig), getCardinality(sig),
+                            sig.isSubset != null, parents, isSubsig, parent, sig.isAbstract != null);
+                })
                 .collect(Collectors.toList());
 
         // get state hierarchy
@@ -138,6 +215,8 @@ public class DashPythonTranslation {
     }
 
     private int getCardinality(Sig sig) {
+        if (sig.isAbstract != null)
+            return 0;
         if (sig.isOne !=null || sig.isLone != null)
             return 1;
         return 3;

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
@@ -15,6 +15,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 
+import java.util.stream.Collectors;
+
 public class CoreDashToPython {
     static DashPythonTranslation dashPythonTranslation;
 
@@ -51,6 +53,7 @@ public class CoreDashToPython {
 
         // add signatures
         vc.put("signatures", dashPythonTranslation.signatures);
+        vc.put("signaturesList", "[" + String.join(", ", dashPythonTranslation.signatures.stream().map(sig -> sig.getName()).collect(Collectors.toList())) + "]");
 
         // add concurrent states
         vc.put("concStateList", dashPythonTranslation.getStates());


### PR DESCRIPTION
The PR mainly supports 3 keywords: "extends", "in" and "abstract".
- "extends" means disjoint subsets
- "abstract" means no additional elements other than its extensions
- "in" means subsets "sig C in A + B {}"

It's impossible to check the validity of all signatures' initial values while doing initialization, so I am taking a two-pass approach. In the first pass only initialize Signature objects, and check validity of initial values in the second pass.

Test-case I used for development: 
```
sig F in A {}
sig Asubset1, Asubset2 extends A {}
sig AAsubset1 extends Asubset1 {}
sig C in A + B {}
sig D in C + A {}
sig E extends A {}
sig A {}
sig B {}
```
