### PR TITLE
Add event tracker, clean up events

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -62,12 +62,9 @@ class State(ABC):
         if(possible_transitions):
             chosen_transition = random.randint(0, len(possible_transitions) - 1)
             possible_transitions[chosen_transition]()
-            return ""
         elif(self._state != self):
-            return self._state.handleEvent()
-        else:
-            return ""
-
+            self._state.handleEvent()
+        
 
 #if($signatures)
 class Signature:
@@ -286,7 +283,7 @@ $padding        logging.log(GCLOG,f"Guard of [${concState.getName()}_${trans.get
 $padding        return True
 
 $padding    # transition ${trans.getTransName()} execution function
-$padding    def _trans_${trans.getTransName()}(self) -> str:
+$padding    def _trans_${trans.getTransName()}(self):
                 #if($globalVariables)
 $padding        # TODO: global variables (signatures used in this state)
                 #foreach($globalVar in $globalVariables)
@@ -333,12 +330,7 @@ class CentralController:
                 activeEvents.clear()
                 activeEvents.add(eventName)
                 # TODO: refactor to only allow 1 transition per conc state in a big step
-                while(True):
-                    new_event = self.concState.handleEvent()
-                    if(new_event != ""):
-                        eventName = new_event
-                    else:
-                        break
+                self.concState.handleEvent()
             elif(eventName != "QUIT"):
                 print("Invalid event name")
 

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -53,8 +53,7 @@ class State(ABC):
     def __ne__(self, obj):
         return type(self) != type(obj)
 
-    def handleEvent(self, eventName: str, vistedStates: set):
-        vistedStates.add(type(self._state))
+    def handleEvent(self, eventName: str):
         possible_transitions = []
         for k, v in self.transitions.items():
             if k(eventName):
@@ -62,10 +61,10 @@ class State(ABC):
 
         if(possible_transitions):
             chosen_transition = random.randint(0, len(possible_transitions) - 1)
-            nextEvent = possible_transitions[chosen_transition]()
-            return nextEvent if (type(self._state) not in vistedStates) else ""
+            possible_transitions[chosen_transition]()
+            return ""
         elif(self._state != self):
-            return self._state.handleEvent(eventName, vistedStates)
+            return self._state.handleEvent(eventName)
         else:
             return ""
 
@@ -219,6 +218,10 @@ for sig in signatures:
     print(sig)
 #end
 
+# --- Active Event Tracker ---
+
+activeEvents = set()
+
 # --- Conc States ---
 #macro(generateState $concState $padding)
 ${padding}class ${concState.getName()}_State(State):
@@ -272,7 +275,7 @@ $padding    # transitions
 $padding    # transition ${trans.getTransName()} guard function
 $padding    def _trans_${trans.getTransName()}_guard(self, current_event: str) -> bool:
 		        #if(${trans.getEventCondition()})
-$padding        if(current_event != "${trans.getEventCondition()}"):
+$padding        if(not ("${trans.getEventCondition()}" in activeEvents)):
 $padding            return False
 		        #end
                 #if($trans.getGuardCondition())
@@ -293,8 +296,9 @@ $padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans
                 #if($trans.getAction())
 $padding        ${trans.getAction()}
                 #end
-$padding        self._parent_state.change_state(self._parent_state.${trans.getToStateName()}_State(self._parent_state, self._root_state))
-$padding        return "${trans.getTriggerEvent()}"
+$padding        new_state = self._parent_state.${trans.getToStateName()}_State(self._parent_state, self._root_state)      
+$padding        self._parent_state.change_state(new_state)
+$padding        #if(${trans.getTriggerEvent()})activeEvents.add("${trans.getTriggerEvent()}") #end
 
             #end
         #end
@@ -310,7 +314,7 @@ class CentralController:
 
     def __init__(self):
         self.concState = $!{rootState.getName()}_State(None, None)
-        self.possibleEvents = {#if(${allEvents.size()} > 0)"${allEvents.get(0).getModifiedName()}"#foreach($event in ${allEvents.subList(1, ${allEvents.size()})}), "$!{event.getModifiedName()}"#end#end}
+        self.possibleEvents = {#if(${allEnvEvents.size()} > 0)"${allEnvEvents.get(0).getModifiedName()}"#foreach($event in ${allEnvEvents.subList(1, ${allEncEvents.size()})}), "$!{event.getModifiedName()}"#end#end}
     
     def run(self) -> None:
         eventName = ""
@@ -326,10 +330,11 @@ class CentralController:
                 eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
 
             if(eventName in self.possibleEvents):
-                # continue to process cascading events until the system is stable
-                vistedStates = set()
+                activeEvents.clear()
+                activeEvents.add(eventName)
+                # TODO: refactor to only allow 1 transition per conc state in a big step
                 while(True):
-                    new_event = self.concState.handleEvent(eventName, vistedStates)
+                    new_event = self.concState.handleEvent(eventName)
                     if(new_event != ""):
                         eventName = new_event
                     else:

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -53,10 +53,10 @@ class State(ABC):
     def __ne__(self, obj):
         return type(self) != type(obj)
 
-    def handleEvent(self, eventName: str):
+    def handleEvent(self):
         possible_transitions = []
         for k, v in self.transitions.items():
-            if k(eventName):
+            if k():
                 possible_transitions.append(v)
 
         if(possible_transitions):
@@ -64,7 +64,7 @@ class State(ABC):
             possible_transitions[chosen_transition]()
             return ""
         elif(self._state != self):
-            return self._state.handleEvent(eventName)
+            return self._state.handleEvent()
         else:
             return ""
 
@@ -273,7 +273,7 @@ $padding        self.transitions[self._trans_${trans.getTransName()}_guard] = se
 $padding    # transitions
             #foreach($trans in $concState.getTransitions())
 $padding    # transition ${trans.getTransName()} guard function
-$padding    def _trans_${trans.getTransName()}_guard(self, current_event: str) -> bool:
+$padding    def _trans_${trans.getTransName()}_guard(self) -> bool:
 		        #if(${trans.getEventCondition()})
 $padding        if(not ("${trans.getEventCondition()}" in activeEvents)):
 $padding            return False
@@ -334,7 +334,7 @@ class CentralController:
                 activeEvents.add(eventName)
                 # TODO: refactor to only allow 1 transition per conc state in a big step
                 while(True):
-                    new_event = self.concState.handleEvent(eventName)
+                    new_event = self.concState.handleEvent()
                     if(new_event != ""):
                         eventName = new_event
                     else:

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -28,7 +28,7 @@ public class DashPythonTranslation {
     private DashModule dashModule;
 
     public List<Signature> signatures;
-    public List<Event> allEvents;
+    public List<Event> allEnvEvents = new ArrayList<Event>();
     public State rootState = null;
     private Map<String, State> concStateMap;
 
@@ -85,13 +85,13 @@ public class DashPythonTranslation {
     public class Event {
     	private String name;
     	private String modifiedName;
-    	private String type; // env event vs event
+    	private boolean isEnvEvent;
     	private State parent;
     	
     	public Event(String name, String modifiedName, String type, State parent) {
     		this.name = name;
     		this.modifiedName = modifiedName;
-    		this.type = type;
+    		this.isEnvEvent = type.equals("env event");
     		this.parent = parent;
     	}
     	
@@ -153,8 +153,6 @@ public class DashPythonTranslation {
                             sig.isSubset != null, parents, isSubsig, parent, sig.isAbstract != null);
                 })
                 .collect(Collectors.toList());
-        
-        this.allEvents = new ArrayList<Event>();
 
         // get state hierarchy
         this.concStateMap = new HashMap<>();
@@ -205,7 +203,9 @@ public class DashPythonTranslation {
         	for(DashEvent event: state.events) {
         		Event newEvent = new Event(event.name, event.modifiedName, event.type, this.concStateMap.get(state.modifiedName));
         		this.concStateMap.get(newEvent);
-        		allEvents.add(newEvent);
+        		if(newEvent.isEnvEvent) {
+        			allEnvEvents.add(newEvent);
+        		}
         	}
         	     	
         	// add substates to conc states

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
@@ -59,7 +59,7 @@ public class CoreDashToPython {
         vc.put("concStateList", dashPythonTranslation.getStates());
         
         // add events
-        vc.put("allEvents", dashPythonTranslation.allEvents);
+        vc.put("allEnvEvents", dashPythonTranslation.allEnvEvents);
         
         vc.put("rootState", dashPythonTranslation.rootState);
 


### PR DESCRIPTION
This PR will:
- Only allow user to enter env events (instead of both env events and internal events)
- Add an event tracker data structure (called activeEvents) that tracks the active events in the Dash model. It's just a set.
- Modify the sendExpr implementation to add a sent event to activeEvents instead of returning it
- Modify the onExpr implementation to check activeEvents instead of the most recently inputted event
- Remove eventName and visitedStates from handleEvent (their functions are now fulfilled by the activeEvents set)
- The generated code (with BitCounter) runs without error (but still only one conc state is active)

See the ticket for sample input and output

Ticket link: https://app.asana.com/0/1200958948599566/1202490699217170/f
