### PR TITLE
Handle default states + no default states

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -243,7 +243,7 @@ $padding        super(#if(${padding} == '')#{else}parent_state.#end${concState.g
 $padding        self._conc_states.append(self.${subState.getName()}_State(self, $rootStateName))
             #end
         #else
-$padding        self.change_state(self.${concState.getSubstates().get(0).getName()}_State(self, $rootStateName))  # go to default state
+$padding        self.change_state(self.${concState.getDefaultSubstate().getName()}_State(self, $rootStateName))  # go to default state
         #end
     #else
 $padding        # No substate for this state, so default state is None

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -216,6 +216,9 @@ public class DashPythonTranslation {
         	for(DashState substate: state.states) {
         		this.concStateMap.get(state.modifiedName).addSubstate(this.concStateMap.get(substate.modifiedName));
         		this.concStateMap.get(substate.modifiedName).parent = concStateMap.get(state.modifiedName);
+        		if(substate.isDefault && this.concStateMap.get(state.modifiedName).defaultSubstate == null) {
+        			this.concStateMap.get(state.modifiedName).defaultSubstate = this.concStateMap.get(substate.modifiedName);
+        		}
         	}
         }
         
@@ -274,6 +277,7 @@ public class DashPythonTranslation {
         private boolean isConc;
         private List<Event> events;
         public State parent = null;
+        public State defaultSubstate = null;
         public State(String stateName, boolean isConc){
             this.stateName = stateName;
             this.transitions = new ArrayList<>();
@@ -301,6 +305,9 @@ public class DashPythonTranslation {
         public void addInit(String s) { inits.add(s); }
         public void addInitConstraint(String s) { init_constraints.add(s); }
         public void addEvent(Event e) { events.add(e); }
+        public State getDefaultSubstate() {
+        	return defaultSubstate != null ? defaultSubstate : substates.get(0);
+        }
     }
 
     public class Transition{


### PR DESCRIPTION
This PR will:
- set the default basic substate (as specified in the Dash model with the "default" keyword) as the initial active_state 
- if no default is specified, the first substate in the core dash representation is selected as the initial active_state
- If multiple states are specified as default, the first default substate in the core dash representation is selected as the initial active_state

See ticket link for sample input/output

Ticket link: https://app.asana.com/0/1200958948599566/1202521721605932/f