### PR TITLE
Simple assignments

### DIFF
--- a/cnf/central.mvn
+++ b/cnf/central.mvn
@@ -12,3 +12,4 @@ biz.aQute:biz.aQute.wrapper.junit:4.13.1
 biz.aQute.bnd:aQute.libg:6.0.0
 com.io7m.jpplib:io7m-jpplib-core:0.7.4
 org.apache.velocity:velocity:1.7
+

--- a/org.alloytools.alloy.application/src/main/java/ca/uwaterloo/watform/dash4whole/RapidDash.java
+++ b/org.alloytools.alloy.application/src/main/java/ca/uwaterloo/watform/dash4whole/RapidDash.java
@@ -41,7 +41,7 @@ public class RapidDash {
         A4Reporter rep = new A4Reporter();
 
         boolean parse = true;
-        boolean toFile = true;
+        boolean toFile = false;
 
         if (parse) {
 

--- a/org.alloytools.alloy.application/src/main/java/ca/uwaterloo/watform/dash4whole/RapidDash.java
+++ b/org.alloytools.alloy.application/src/main/java/ca/uwaterloo/watform/dash4whole/RapidDash.java
@@ -41,7 +41,7 @@ public class RapidDash {
         A4Reporter rep = new A4Reporter();
 
         boolean parse = true;
-        boolean toFile = false;
+        boolean toFile = true;
 
         if (parse) {
 

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -359,9 +359,11 @@ $padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans
                 #if($trans.getAction())
 $padding        ${trans.getAction()}
                 #end
-$padding        new_state = self._parent_state.${trans.getToStateName()}_State(self._parent_state, self._root_state)      
+$padding        new_state = self._parent_state.${trans.getToStateName()}_State(self._parent_state, self._root_state)
 $padding        self._parent_state.change_state(new_state)
-$padding        #if(${trans.getTriggerEvent()})SS.activeEvents.add("${trans.getTriggerEvent()}") #end
+                #if(${trans.getTriggerEvent()})
+$padding        SS.activeEvents.add("${trans.getTriggerEvent()}")
+                #end
 
             #end
         #end
@@ -383,7 +385,7 @@ class CentralController:
         #else
         self.possibleEvents = {}
         #end
-    
+
     def run(self) -> None:
         eventName = ""
         # big step

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -10,16 +10,16 @@ import random
 
 # ===== logging =====
 
-GCLOG = logging.DEBUG+1  # used for guard condition
-ACLOG = logging.DEBUG+2  # used for action chosen
-CALOG = logging.DEBUG+3  # used for feedback on adding called
-SVLOG = logging.DEBUG+4  # used for signature validity check
+CALOG = logging.DEBUG+1  # used for feedback on adding called
+SVLOG = logging.DEBUG+2  # used for signature validity check
+GCLOG = logging.INFO+1  # used for guard condition
+ACLOG = logging.INFO+2  # used for action chosen
 
 logging.basicConfig(level=logging.INFO)
-logging.addLevelName(GCLOG, "GUARD")
-logging.addLevelName(ACLOG, "ACTION")
 logging.addLevelName(CALOG, "CALLED")
 logging.addLevelName(SVLOG, "SIG")
+logging.addLevelName(GCLOG, "GUARD")
+logging.addLevelName(ACLOG, "ACTION")
 
 # ===== Base Classes =====
 
@@ -356,9 +356,11 @@ $padding        # TODO: global variables (signatures used in this state)
 $padding        global ${globalVar}
                 #end#end
 $padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans.getTransName()}] triggered.")
-                #if($trans.getAction())
-$padding        ${trans.getAction()}
+            #if($trans.getActions())
+                #foreach($action in $trans.getActions())
+$padding        ${action}
                 #end
+            #end
 $padding        new_state = self._parent_state.${trans.getToStateName()}_State(self._parent_state, self._root_state)
 $padding        self._parent_state.change_state(new_state)
                 #if(${trans.getTriggerEvent()})
@@ -380,6 +382,7 @@ class CentralController:
 
     def __init__(self):
         self.concState = $!{rootState.getName()}_State(None, None)
+        self.commands = {"help": self.printHelp, "states": self.printStates, "execute": self.execute}
         #if(${allEnvEvents.size()}> 0)
         self.possibleEvents = {"${allEnvEvents.get(0).getModifiedName()}"#foreach($event in ${allEnvEvents.subList(1, ${allEncEvents.size()})}), "$!{event.getModifiedName()}"#end}
         #else
@@ -389,33 +392,39 @@ class CentralController:
     def run(self) -> None:
         eventName = ""
         # big step
-        while(eventName != "QUIT"):
-            eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
-
-            while(eventName == "help" or eventName == "states"):
-                if(eventName == "help"):
-                    print("\nEnv Events:")
-                    #if(${allEnvEvents.size()}> 0)
-                    for x in self.possibleEvents:
-                        print(x)
-                    #end
-                    print("\nOther Commands:")
-                    print("states: print the model's current states")
-                    print("QUIT: terminate the model\n")
-                elif(eventName == "states"):
-                    print("\n" + type(self.concState).__name__ + " Current States:\n")
-                    self.concState.printStates()
-
-                eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
-
-            if(eventName in self.possibleEvents):
+        while eventName.lower() != "quit":
+            if eventName in self.possibleEvents:
                 SS.activeEvents.clear()
                 SS.activeEvents.add(eventName)
-                # TODO: refactor to only allow 1 transition per conc state in a big step
                 self.concState.handleEvent()
-            elif(eventName != "QUIT"):
+            elif eventName != "":
                 print("Invalid event name")
 
+            eventName = input("Please enter an event to be processed by the model. Type \"help\" for a list of possible events\n")
+            while eventName == "":
+                eventName = input()
+
+            if eventName in self.commands:
+                self.commands[eventName]()
+                eventName = ""
+
+    def printHelp(self):
+        print("\n-- Env Events --")
+        #if(${allEnvEvents.size()}> 0)
+        for x in self.possibleEvents:
+            print(x)
+        #end
+        print("\n-- Other Commands --")
+        print("states: print the model's current states")
+        print("execute: take a random transition (if possible)")
+        print("quit: terminate the model\n")
+
+    def printStates(self):
+        print("\n" + type(self.concState).__name__ + " Current States:\n")
+        self.concState.printStates()
+
+    def execute(self):
+        self.concState.handleEvent()
 
 # --- Run the Model ---
 

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -362,9 +362,9 @@ public class DashPythonTranslationTest {
         assertEquals( 6,transitions.size());
 
         List<String> expectedString = Arrays.asList(
-                "SigA.issubset(near)",
-                "not SigA.issubset(near)",
-                "not(not SigA.issubset(near))",
+                "SigA in SS.StateA_near",
+                "SigA not in SS.StateA_near",
+                "not(SigA not in SS.StateA_near)",
                 "SigA != SigB",
                 "not(SigA)",
                 "not(SigA != SigB)");
@@ -400,21 +400,21 @@ public class DashPythonTranslationTest {
         assertEquals(12, transitions.size());
 
         List<String> expectedString = Arrays.asList(
-                "far = far",
-                "far = far",
-                "far = far",
-                "far = (far | SigA)",
-                "far = (far | SigA | SigB)",
-                "far = (far | SigA | SigB)",
-                "far = (far | (SigB | SigA))",
-                "far = (far - SigA)",
-                "far = (far - SigA - SigB)",
-                "far = (far - SigA - SigB)",
-                "far = (far - (SigA - SigB))",
-                "far = (far | SigA - (SigB - far))");
+                "SS.StateA_far = SS.StateA_far",
+                "SS.StateA_far = SS.StateA_far",
+                "SS.StateA_far = SS.StateA_far",
+                "SS.StateA_far = SS.StateA_far + SigA",
+                "SS.StateA_far = SS.StateA_far + SigA + SigB",
+                "SS.StateA_far = SS.StateA_far + SigA + SigB",
+                "SS.StateA_far = SS.StateA_far + (SigB + SigA)",
+                "SS.StateA_far = SS.StateA_far - SigA",
+                "SS.StateA_far = SS.StateA_far - SigA - SigB",
+                "SS.StateA_far = SS.StateA_far - SigA - SigB",
+                "SS.StateA_far = SS.StateA_far - (SigA - SigB)",
+                "SS.StateA_far = SS.StateA_far + SigA - (SigB - SS.StateA_far)");
 
         for (int index = 0; index < transitions.size(); index++) {
-            assertEquals(expectedString.get(index), transitions.get(index).getAction());
+            assertEquals(expectedString.get(index), transitions.get(index).getActions().get(0));
         }
     }
 

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -357,7 +357,7 @@ public class DashExprToPython<ExprType> {
                 res = this.genExpr(node.left, 1) + " in ";
                 break;
             case NOT_IN:        // this part assumes inner expression are a signature instances and are sets
-                res = "not " + this.genExpr(node.left, 1) + " not in";
+                res = this.genExpr(node.left, 1) + " not in ";
                 break;
             case AND:           // this part assumes the inner expression is a statement that evaluates to true or false
                 res = "(" + this.genExpr(node.left, 1) + ") and ";

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -6,9 +6,12 @@ import edu.mit.csail.sdg.ast.Expr;
 import edu.mit.csail.sdg.ast.ExprBadJoin;
 import edu.mit.csail.sdg.ast.ExprBinary;
 import edu.mit.csail.sdg.ast.ExprConstant;
+import edu.mit.csail.sdg.ast.ExprList;
 import edu.mit.csail.sdg.ast.ExprUnary;
 import edu.mit.csail.sdg.ast.ExprVar;
 
+import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
@@ -18,7 +21,7 @@ import java.util.Map;
  */
 public class DashExprToPython<ExprType> {
     private ExprType specialExpr;
-    private StringBuilder sb;
+    private Deque<StringBuilder> sbs;
     private Map<String, String> variable2StateNameMap;
     private String varName;;
     private List<DashPythonTranslation.Relation> relations;
@@ -27,7 +30,8 @@ public class DashExprToPython<ExprType> {
 
     public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations){
         this.specialExpr = specialExpr;
-        this.sb = new StringBuilder();
+        this.sbs = new LinkedList<>();
+        this.sbs.addLast(new StringBuilder());
         this.variable2StateNameMap = variable2StateNameMap;
         this.varName = varName;
         this.relations = relations;
@@ -42,12 +46,23 @@ public class DashExprToPython<ExprType> {
 
     @Override
     public String toString() {
-        return this.sb.toString();
+        return this.sbs.getLast().toString();
+    }
+
+    public List<String> toList(){
+        List<String> result = new LinkedList<>();
+        for (StringBuilder sb : sbs) {
+            if (sb.length() > 0){
+                result.add(sb.toString());
+            }
+        }
+        return result;
     }
     
     public void reparseExpr() {
-    	this.sb = new StringBuilder();
-    	this.parseExpr();
+        sbs.removeLast();
+        sbs.addLast(new StringBuilder());
+    	parseExpr();
     }
 
     // generate python expressions
@@ -55,13 +70,13 @@ public class DashExprToPython<ExprType> {
         // TODO: need to handle predicates with multiple lines
         if(specialExpr instanceof DashWhenExpr){
             DashWhenExpr exp = (DashWhenExpr)this.specialExpr;
-            sb.append(genExpr(exp.getExpr(), exp.getAllExpressions().size()));
+            sbs.getLast().append(genExpr(exp.getExpr(), exp.getAllExpressions().size()));
         } else if (specialExpr instanceof DashDoExpr){
             // TODO: Do expr should be different since actions are needed, not just evaluation statements
             DashDoExpr exp = (DashDoExpr)this.specialExpr;
-            sb.append(genExpr(exp.getExpr(), exp.getAllExpression().size()));
+            sbs.getLast().append(genExpr(exp.getExpr(), exp.getAllExpression().size()));
         } else {
-        	sb.append(genExpr((Expr)specialExpr, 1));
+            sbs.getLast().append(genExpr((Expr)specialExpr, 1));
         }
     }
 
@@ -70,35 +85,41 @@ public class DashExprToPython<ExprType> {
         // TODO: currently, the second parameter is redundant
 
         // check type, there are two types of expr
-        if (node instanceof ExprUnary) {
+        if (node instanceof  ExprList) {
+            ExprList exprList = (ExprList) node;
+            // Assuming each expr in the list is an independent statement
+            for (Expr subNode : exprList.args) {
+                sbs.getLast().append(genExpr(subNode, exprList.args.size()));
+                sbs.addLast(new StringBuilder());
+            }
+            return "";
+        }else if (node instanceof ExprUnary) {
             // TODO: is sub always a binary?
 
-            // variable2StateNameMap
-
             ExprUnary unaryNode = (ExprUnary) node;
-            return(UnaryOp2PythonOp(unaryNode.op, unaryNode.sub));
+            return UnaryOp2PythonOp(unaryNode.op, unaryNode.sub);
         } else if (node instanceof ExprBinary) {
             // TODO: will BinaryExpr have sub nodes?
 
             // TODO: will need to replace left and right with signature names
-            ExprBinary binaryNode = (ExprBinary) node;
-            return(BinaryOp2PythonOp(binaryNode));
+            return BinaryOp2PythonOp((ExprBinary) node);
         } else if (node instanceof ExprVar || node instanceof ExprConstant){
+            String varName = node.toString();
             if('\'' == node.toString().charAt(node.toString().length() - 1)){
-                return node.toString().substring(0, node.toString().length() - 1);
+                varName = node.toString().substring(0, node.toString().length() - 1);
             }
-			return node.toString();
+			return getVarName(varName);
         } else if (node instanceof ExprBadJoin) {
-        	// this assumes the expr is in the form (#STATE_VARIABLE).PLUS/MINUS[CONSTANT]
-        	ExprBadJoin badNode = (ExprBadJoin)node;
-        	ExprBadJoin badSubnode = (ExprBadJoin)badNode.right;
-        	ExprUnary cardinality = (ExprUnary) badSubnode.left;// #STATE_VARIABLE
-        	String type = badSubnode.right.toString();// plus or minus
-        	String operation = type.equals("plus") ? " + " : " - ";
-        	return UnaryOp2PythonOp(cardinality.op, cardinality.sub) + operation + badNode.left.toString();
+            // this assumes the expr is in the form (#STATE_VARIABLE).PLUS/MINUS[CONSTANT]
+            ExprBadJoin badNode = (ExprBadJoin) node;
+            ExprBadJoin badSubnode = (ExprBadJoin) badNode.right;
+            ExprUnary cardinality = (ExprUnary) badSubnode.left;// #STATE_VARIABLE
+            String type = badSubnode.right.toString();// plus or minus
+            String operation = type.equals("plus") ? " + " : " - ";
+            return UnaryOp2PythonOp(cardinality.op, cardinality.sub) + operation + badNode.left.toString();
         } else {
             // under development, use this to catch more types that could be useful
-            System.out.println("More types: " + node.getClass());
+            System.out.println("[Warning] Need more types: " + node.getClass());
         }
         return "";
     }
@@ -186,7 +207,7 @@ public class DashExprToPython<ExprType> {
     // translate Binary operation, also returns the empty space
     private String BinaryOp2PythonOp(ExprBinary node){
         String res = " ";
-        boolean addParanthesis = false;
+        boolean addParanthesis = node.right instanceof ExprBinary;
         boolean rightConsumed = false;
         switch(node.op){
             case ARROW:     // State relation declaration
@@ -265,7 +286,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case PLUS:        // this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " | ";
+                res = this.genExpr(node.left, 1) + " + ";
                 break;
             case IPLUS:
                 res = " ";
@@ -291,7 +312,7 @@ public class DashExprToPython<ExprType> {
             	} else {
             		res = this.genExpr(node.left, 1) + " = ";
             	}
-                
+                addParanthesis = false;
                 break;
             case NOT_EQUALS:    // this part assumes inner expression is a signature instances and are comparable
                 res = this.genExpr(node.left, 1) + " != ";
@@ -333,12 +354,10 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case IN:            // this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + ".issubset";
-                addParanthesis = true;
+                res = this.genExpr(node.left, 1) + " in ";
                 break;
             case NOT_IN:        // this part assumes inner expression are a signature instances and are sets
-                res = "not " + this.genExpr(node.left, 1) + ".issubset";
-                addParanthesis = true;
+                res = "not " + this.genExpr(node.left, 1) + " not in";
                 break;
             case AND:           // this part assumes the inner expression is a statement that evaluates to true or false
                 res = "(" + this.genExpr(node.left, 1) + ") and ";
@@ -364,11 +383,18 @@ public class DashExprToPython<ExprType> {
         }
 
         // add paranthesis for right node
-        if(addParanthesis || node.right instanceof ExprBinary){
+        if(addParanthesis){
             res += "(" + this.genExpr(node.right, 1) + ")";
         }else if (!rightConsumed){
             res += this.genExpr(node.right, 1);
         }
         return res;
+    }
+
+    private String getVarName(String varName){
+        if (variable2StateNameMap.containsKey(varName)){
+            return "SS." + variable2StateNameMap.get(varName) + "_" + varName;
+        }
+    	return varName;
     }
 }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -686,7 +686,7 @@ public class DashPythonTranslation {
                 this.actions = dashExprTranslator.toList();
             }
             if(dashTrans.getDestination() != null){    // determine the next state
-                this.toStateName = dashTrans.getDestination().getAllDestinations().get(0);
+                this.toStateName = dashTrans.getDestination().getAllDestinations().get(0).replace("/", "_");
             }
             if(dashTrans.getEventsTriggered() != null){    // determines the event to send
                 this.triggerEvent = dashTrans.getEventsTriggered().getRawName();

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -651,7 +651,7 @@ public class DashPythonTranslation {
         private String fromStateName = "";
         private String toStateName = "";
         private String transName = "";                       // transition name
-        private String action = "";                          // the logic for this transition to be executed
+        private List<String> actions = new ArrayList<>();    // the logic for this transition to be executed
         private String guardCondition = "";                  // the guard condition of this transition
         private String eventCondition = "";
         private String triggerEvent = "";
@@ -682,8 +682,8 @@ public class DashPythonTranslation {
             if(dashTrans.getAction() != null){      // determines the action
                 DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap);
 
-                // set action
-                this.action = dashExprTranslator.toString();
+                // set actions
+                this.actions = dashExprTranslator.toList();
             }
             if(dashTrans.getDestination() != null){    // determine the next state
                 this.toStateName = dashTrans.getDestination().getAllDestinations().get(0);
@@ -698,7 +698,7 @@ public class DashPythonTranslation {
         public String getTransName(){return transName;}
         public String getStateName(){return stateName;}
         public String getGuardCondition(){return guardCondition;}
-        public String getAction(){return action;}
+        public List<String> getActions(){return actions;}
         public String getEventCondition() {return eventCondition;}
         public String getFromStateName() {return fromStateName;}
         public String getToStateName() {return toStateName;}


### PR DESCRIPTION
- This PR is to implement basic assignments for variables. Aim to have runnable code for a simple model. This works for one of the models but fails for another due to an issue with the state hierarchy. I will talk about what went wrong with one of the models.
- Another major change in this PR is the central controller. I rearranged the code in the central controller for basic commands and also to allow it to execute transitions in the states. We were not allowed to execute transitions without events before this. (@AidanCampbell738 @Simonliuwaterloo please be aware of this change)

Results:  
Dash model:
```
abstract sig Object { eats: set Object}
one sig Chicken, Farmer extends Object {}
conc state SimpleAssignments {
    conc state R{
        near: set Object
        far: set Object
        trans addFarmerChicken2near {
            do {
                near' = near + Farmer + Chicken
                far' = far - Farmer + Chicken
            }
        }
    }
}
```
Python code (only the transitions) 
```
# transition addFarmerChicken2near guard function
def _trans_addFarmerChicken2near_guard(self) -> bool:
    logging.log(GCLOG,f"Guard of [SimpleAssignments_R_addFarmerChicken2near] triggered.")
    return True

# transition addFarmerChicken2near execution function
def _trans_addFarmerChicken2near(self):
    logging.log(ACLOG,f"Execution of [SimpleAssignments_R_addFarmerChicken2near] triggered.")
    SS.SimpleAssignments_R_near = SS.SimpleAssignments_R_near + Farmer + Chicken
    SS.SimpleAssignments_R_far = SS.SimpleAssignments_R_far - Farmer + Chicken
    new_state = self._parent_state.SimpleAssignments_R_State(self._parent_state, self._root_state)
    self._parent_state.change_state(new_state)
```

Failed case:  
- Only one root conc state, so the `_parent_state` of the only state is `None`. However, it seems we don't have checks in the template file for this case so the code uses the `_parent_state` variable like it's not `None`.  

Dash Model:
```
abstract sig Object { eats: set Object}
one sig Chicken, Farmer extends Object {}
conc state SimpleAssignments {
    trans addFarmer2near {
        do {
            near' = near + Farmer
            far' = far - Farmer
        }
    }
}
```
Output: (line 280 to line 301)
```
class SimpleAssignments_State(State):

    def __init__(self, parent_state: State, root_state: State) -> None:
        super(SimpleAssignments_State, self).__init__(None, self) # init superclass
        # No substate for this state, so default state is None

        # initialize state transition dictionary
        self.transitions[self._trans_addFarmer2near_guard] = self._trans_addFarmer2near

    # transitions
    # transition addFarmer2near guard function
    def _trans_addFarmer2near_guard(self) -> bool:
        logging.log(GCLOG,f"Guard of [SimpleAssignments_addFarmer2near] triggered.")
        return True

    # transition addFarmer2near execution function
    def _trans_addFarmer2near(self):
        logging.log(ACLOG,f"Execution of [SimpleAssignments_addFarmer2near] triggered.")
        near = near + Farmer
        far = far - Farmer
        new_state = self._parent_state.SimpleAssignments_State(self._parent_state, self._root_state)
        self._parent_state.change_state(new_state)
```
