### PR TITLE
Basic guard expressions

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -347,10 +347,20 @@ $padding    def _trans_${trans.getTransName()}_guard(self) -> bool:
 $padding        if(not ("${trans.getEventCondition()}" in SS.activeEvents)):
 $padding            return False
 		        #end
-                #if($trans.getGuardCondition())
-$padding        if not (${trans.getGuardCondition()}):
+            #if($trans.getGuardConditions())
+                #if($trans.getGuardConditions().size() == 1)
+$padding        if not ($trans.getGuardConditions().get(0)):
+$padding            return False
+                #else
+$padding        if not ($trans.getGuardConditions().get(0) and
+                    #set($lastIndex = ${trans.getGuardConditions().size()} - 1)
+                    #foreach($guardCondition in ${trans.getGuardConditions().subList(1, $lastIndex)})
+$padding                ${guardCondition} and
+                    #end
+$padding                ${trans.getGuardConditions().get($lastIndex)}):
 $padding            return False
                 #end
+            #end
 $padding        logging.log(GCLOG,f"Guard of [${concState.getName()}_${trans.getTransName()}] triggered.")
 $padding        return True
 
@@ -361,7 +371,7 @@ $padding        # TODO: global variables (signatures used in this state)
                 #foreach($globalVar in $globalVariables)
 $padding        global ${globalVar}
                 #end#end
-$padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans.getTransName()}] triggered.")
+$padding        logging.log(ACLOG,f"Execution of [${concState.getName()}_${trans.getTransName()}] passed.")
             #if($trans.getActions())
                 #foreach($action in $trans.getActions())
 $padding        ${action}

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -12,14 +12,18 @@ import random
 
 CALOG = logging.DEBUG+1  # used for feedback on adding called
 SVLOG = logging.DEBUG+2  # used for signature validity check
-GCLOG = logging.INFO+1  # used for guard condition
-ACLOG = logging.INFO+2  # used for action chosen
+GCLOG = logging.INFO+1   # used for guard condition
+ACLOG = logging.INFO+2   # used for action chosen
+VARLOG = logging.INFO+3  # used for variables
+SCLOG = logging.INFO+4   # used for state change
 
 logging.basicConfig(level=logging.INFO)
-logging.addLevelName(CALOG, "CALLED")
+logging.addLevelName(CALOG, "CALL")
 logging.addLevelName(SVLOG, "SIG")
 logging.addLevelName(GCLOG, "GUARD")
 logging.addLevelName(ACLOG, "ACTION")
+logging.addLevelName(VARLOG, "VAR")
+logging.addLevelName(SCLOG, "STATE")
 
 # ===== Base Classes =====
 
@@ -49,7 +53,7 @@ class State(ABC):
 
     def change_state(self, state: State):
         if(self._active_state is not None):
-            logging.info(f"{self._active_state} => {state}")
+            logging.log(SCLOG, f"State change: {self._active_state} => {state}")
         self._active_state = state
 
     def __eq__(self, obj):
@@ -237,6 +241,7 @@ class Snapshot:
     def __setattr__(self, name, value):
         if name in self.__dict__:       # Record the variables for current snapshot.
             self.changes[name] = self.__dict__[name]
+            logging.log(VARLOG,f"Variable [{name}] changed from \"{self.changes[name]}\" to \"{value}\".")
         self.__dict__[name] = value     # Set the value.
 
     # TODO: delete this comment.

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -370,7 +370,7 @@ public class DashPythonTranslationTest {
                 "not(SigA != SigB)");
 
         for(int index = 0; index < transitions.size(); index++){
-            assertEquals(expectedString.get(index), transitions.get(index).getGuardCondition());
+            assertEquals(expectedString.get(index), transitions.get(index).getGuardConditions().get(0));
         }
     }
 

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -716,7 +716,7 @@ public class DashPythonTranslation {
         private String toStateName = "";
         private String transName = "";                       // transition name
         private List<String> actions = new ArrayList<>();    // the logic for this transition to be executed
-        private String guardCondition = "";                  // the guard condition of this transition
+        private List<String> guardConditions = new ArrayList<>();   // the guard conditions of this transition
         private String eventCondition = "";
         private String triggerEvent = "";
         private String transTemplate = "";
@@ -741,7 +741,7 @@ public class DashPythonTranslation {
                 DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap);
 
                 // set condition
-                this.guardCondition = dashExprTranslator.toString();
+                this.guardConditions = dashExprTranslator.toList();
             }
             if(dashTrans.getAction() != null){      // determines the action
                 DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap);
@@ -761,7 +761,7 @@ public class DashPythonTranslation {
         }
         public String getTransName(){return transName;}
         public String getStateName(){return stateName;}
-        public String getGuardCondition(){return guardCondition;}
+        public List<String> getGuardConditions(){return guardConditions;}
         public List<String> getActions(){return actions;}
         public String getEventCondition() {return eventCondition;}
         public String getFromStateName() {return fromStateName;}


### PR DESCRIPTION
Changes:
- Now we can handle guard conditions with multiple lines

Notes:
- We can run the compiled code, but it won't function correctly. This is because we will call the `__init__()` of the states when we change the state in the current code base (in other words, pending on state hierarchy to provide a "singleton" solution). Other than that, the values of the variables should be changed properly if corresponding actions are taken.

Input:
```
abstract sig Object {}
one sig Chicken, Farmer, Fox, Grain extends Object {}
conc state Puzzle {
    default state R{
        near: set Object
        far: set Object

        trans move_all_to_Near {
            when {
                Farmer not in near
                Fox not in near
                Chicken not in near
                Grain not in near
                }
            do {
                near' = near + Farmer + Fox + Chicken + Grain
                far' = far - Farmer - Fox - Chicken - Grain
                }
        }

        trans swap_Farmer_Fox_Forward {
            when {
                Farmer in near
                Fox not in near
                }
            do {
                near' = near - Farmer + Fox
                far' = far + Farmer - Fox
                }
        }

        trans swap_Farmer_Fox_Backward {
            when {
                Farmer not in near
                Fox in near
                }
            do {
                near' = near + Farmer - Fox
                far' = far - Farmer + Fox
                }
        }
    }
}
```
Python output (The guard conditions):
```
def _trans_move_all_to_Near_guard(self) -> bool:
    if not (Farmer not in SS.Puzzle_R_near and
            Fox not in SS.Puzzle_R_near and
            Chicken not in SS.Puzzle_R_near and
            Grain not in SS.Puzzle_R_near):
        return False
    logging.log(GCLOG,f"Guard of [Puzzle_R_move_all_to_Near] triggered.")
    return True

# transition swap_Farmer_Fox_Forward guard function
def _trans_swap_Farmer_Fox_Forward_guard(self) -> bool:
    if not (Farmer in SS.Puzzle_R_near and
            Fox not in SS.Puzzle_R_near):
        return False
    logging.log(GCLOG,f"Guard of [Puzzle_R_swap_Farmer_Fox_Forward] triggered.")
    return True

# transition swap_Farmer_Fox_Backward guard function
def _trans_swap_Farmer_Fox_Backward_guard(self) -> bool:
    if not (Farmer not in SS.Puzzle_R_near and
            Fox in SS.Puzzle_R_near):
        return False
    logging.log(GCLOG,f"Guard of [Puzzle_R_swap_Farmer_Fox_Backward] triggered.")
    return True
```
