### PR TITLE
Support more operators

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -454,11 +454,14 @@ $padding        # TODO: global variables (signatures used in this state)
 $padding        global ${globalVar}
                 #end#end
 $padding        print(Blue + "Taking transition " + "${trans.getTransName()}" + Reset)
-            #if($trans.getActions())
+            #if(!$trans.getActions().isEmpty())
                 #foreach($action in $trans.getActions())
 $padding        ${action}
-            #end#end
-$padding        #if(${trans.getTriggerEvent()})SS.activeEvents.add("${trans.getTriggerEvent()}") #end
+                #end
+            #end
+            #if(${trans.getTriggerEvent()})
+$padding        SS.activeEvents.add("${trans.getTriggerEvent()}")
+            #end
 $padding        # Apply State Activeness Changes
                 #if($trans.getNonActiveStatesAfterTrans().size() > 0)
 $padding        # size = $trans.getNonActiveStatesAfterTrans().size()
@@ -499,14 +502,14 @@ class CentralController:
         #else
         self.possibleEvents = {}
         #end
-    
+
     def handle_event(self):
         unused_conc_states = {self.concState#foreach($value in $allStates)#if($value.getIsConc() && !$value.isRootState()), $value.getPythonVariableName()#end#end} # set of conc states that haven't taken a transition in this big step
         conc_state_to_active_child = dict() # dictionary that maps each conc state to its active child at the start of this big step
         for conc_state in unused_conc_states:
             conc_state_to_active_child[conc_state] = conc_state.get_active_child_state()
         prev_num_unused_conc_states = -1
-        
+
         while len(unused_conc_states) > 0 and prev_num_unused_conc_states != len(unused_conc_states):
             prev_num_unused_conc_states = len(unused_conc_states)
             state_queue = [self.concState]
@@ -534,7 +537,7 @@ class CentralController:
                 # add cur_state's active state to queue
                 elif cur_state.get_active_child_state() is not None:
                     state_queue.append(cur_state.get_active_child_state())
-    
+
     def run(self) -> None:
         self.concState.print_tree()
         self.printHelp()

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -273,6 +273,9 @@ class Relation(metaclass = MetaSet):
         domain_elements = [type.objects() for type in cls.types]
         return set([tup for tup in itertools.product(*domain_elements)])
 
+    def __repr__(self):
+        return f"{self.__class__.__name__} - {self.name} : {self.values}" if self.values else f"{self.__class__.__name__} - {self.name} : Empty"
+
     # override "in" operator, e.g.,: other in self
     def __contains__(self, other):
         return  MetaSet.Set(other) in MetaSet.Set(self.values)
@@ -302,10 +305,15 @@ class VariableTracker:
         self.activeEvents = set()
 
     def __setattr__(self, name, value):
-        if name in self.__dict__:       # Record the variables for current snapshot.
+        if name in self.__dict__:
             self.changes[name] = self.__dict__[name]
-            logging.log(VARLOG,f"Variable [{name}] changed from \"{self.changes[name]}\" to \"{value}\".")
-        self.__dict__[name] = value     # Set the value.
+            if isinstance(self.changes[name], Relation):
+                self.__dict__[name].values = value
+            else: # Assume only Relation and Signature instances are used.
+                self.__dict__[name].elements = value
+            logging.log(VARLOG,f"Variable [{name}] changed from \"{self.changes[name]}\" to \"{self.__dict__[name]}\".")
+        else:
+            self.__dict__[name] = value     # Initialization of variables.
 
     # TODO: delete this comment.
     # Call this when a big step is made.
@@ -453,7 +461,7 @@ $padding        # TODO: global variables (signatures used in this state)
                 #foreach($globalVar in $globalVariables)
 $padding        global ${globalVar}
                 #end#end
-$padding        print(Blue + "Taking transition " + "${trans.getTransName()}" + Reset)
+$padding        print(Blue + "Taking transition ${trans.getTransName()}" + Reset)
             #if(!$trans.getActions().isEmpty())
                 #foreach($action in $trans.getActions())
 $padding        ${action}
@@ -477,7 +485,7 @@ $padding            state.is_active = True
                 #end
                 #if(${trans.getTriggerEvent()})
 $padding        SS.activeEvents.add("${trans.getTriggerEvent()}")
-$padding        print(Cyan + "Sending event " + "${trans.getTriggerEvent()}" + Reset)
+$padding        print(Cyan + "Sending event ${trans.getTriggerEvent()}" + Reset)
                 #end
 
             #end

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -219,6 +219,11 @@ class Signature(metaclass = MetaSet):
     def __sub__(self, other):
         return MetaSet.Set(self.elements) - MetaSet.Set(other)
 
+    # override "*" operator as cartesian product
+    def __mul__(self, other) -> set(tuple):
+        return set(itertools.product(self.elements, other.elements))
+
+
 class Relation(metaclass = MetaSet):
     def __init__(self, name, types, values=set()):
         """

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -87,33 +87,37 @@ class State(ABC):
 
 #end
 #if($signatures)
-class MetaSignature(type):
+class MetaSet(type):
     """
-    Used by Signatures (statically)
-    - the member variables and functions will be used by Signature Classes themselves, not the instances
+    Used by variables to make operations consistent.
+    - static variable is a class and a dynamic variable is an instance
     """
 
     class Set:
         """
-        used to make more operations between Signature and instances of Signatures easier
+        Everything will be turned into a set. Set of strings or set of tuples.
         """
         def __init__(self, initvalue=()):
-            if isinstance(initvalue, MetaSignature.Set):
+            if isinstance(initvalue, MetaSet.Set):
                 self._set = initvalue._set
             elif isinstance(initvalue, set):
                 self._set = initvalue
             elif isinstance(initvalue, list):
                 self._set = set(initvalue)
-            elif isinstance(initvalue, MetaSignature):
+            elif isinstance(initvalue, MetaSet):
                 self._set = initvalue.objects()
             elif isinstance(initvalue, Signature):
                 self._set = initvalue.elements
+            elif isinstance(initvalue, Relation):
+                self._set = initvalue.values
+            elif isinstance(initvalue, tuple):
+                self._set = {initvalue}
             elif isinstance(initvalue, str):
                 self._set = {initvalue}
             elif isinstance(initvalue, int):
                 self._set = {initvalue}
             else:
-                print("Exception, unsupported type in MetaSignature::Set: %s", type(initvalue))
+                print("Exception, unsupported type in MetaSet::Set: %s", type(initvalue))
 
         def __iter__(self):
             return iter(self._set)
@@ -123,44 +127,42 @@ class MetaSignature(type):
 
         # override "in" operator, e.g.,: other in cls
         def __contains__(cls, other) -> bool:
-            if not isinstance(other, MetaSignature.Set):
-                return MetaSignature.Set(other) in cls
+            if not isinstance(other, MetaSet.Set):
+                return MetaSet.Set(other) in cls
             return other._set.issubset(cls._set)
 
         # override "+" operator, e.g.,: cls + other
-        def __add__(cls, other) -> MetaSignature.Set:
-            if not isinstance(other, MetaSignature.Set):
-                return cls + MetaSignature.Set(other)
-            return MetaSignature.Set(cls._set.union(other._set))
+        def __add__(cls, other) -> MetaSet.Set:
+            if not isinstance(other, MetaSet.Set):
+                return cls + MetaSet.Set(other)
+            return MetaSet.Set(cls._set.union(other._set))
 
         # override "-" operator, e.g.,: cls - other
-        def __sub__(cls, other) -> MetaSignature.Set:
-            if not isinstance(other, MetaSignature.Set):
-                return cls - MetaSignature.Set(other)
-            return MetaSignature.Set(cls._set.difference(other._set))
+        def __sub__(cls, other) -> MetaSet.Set:
+            if not isinstance(other, MetaSet.Set):
+                return cls - MetaSet.Set(other)
+            return MetaSet.Set(cls._set.difference(other._set))
 
     # override "in" operator, e.g.,: other in cls
     def __contains__(cls, other):
-        return  MetaSignature.Set(other) in MetaSignature.Set(cls.objects())
+        return  MetaSet.Set(other) in MetaSet.Set(cls.objects())
 
     # override "+" operator, e.g.,: cls + other
     def __add__(cls, other):
-        return MetaSignature.Set(cls.objects()) + MetaSignature.Set(other)
+        return MetaSet.Set(cls.objects()) + MetaSet.Set(other)
 
     # override "-" operator, e.g.,: cls - other
     def __sub__(cls, other):
-        return MetaSignature.Set(cls.objects()) - MetaSignature.Set(other)
+        return MetaSet.Set(cls.objects()) - MetaSet.Set(other)
 
-    # all objects in this Signature
+    # all objects in this static variable
     def objects(cls) -> set:
-        return cls.atoms
-
-    # the scope of this Signature
-    def scope(cls) -> int:
-        return len(cls.objects())
+        if hasattr(cls, 'possible_tuples'):
+            return cls.possible_tuples()    # Relation
+        return cls.atoms                    # Signature
 
 
-class Signature(metaclass = MetaSignature):
+class Signature(metaclass = MetaSet):
     def __init__(self, name, multiplicity, elements=set()):
         """
         Used by state variables
@@ -207,17 +209,17 @@ class Signature(metaclass = MetaSignature):
 
     # override "in" operator, e.g.,: other in self
     def __contains__(self, other):
-        return  MetaSignature.Set(other) in MetaSignature.Set(self.elements)
+        return  MetaSet.Set(other) in MetaSet.Set(self.elements)
 
     # override "+" operator, e.g.,: self + other
     def __add__(self, other):
-        return MetaSignature.Set(self.elements) + MetaSignature.Set(other)
+        return MetaSet.Set(self.elements) + MetaSet.Set(other)
 
     # override "-" operator, e.g.,: self - other
     def __sub__(self, other):
-        return MetaSignature.Set(self.elements) - MetaSignature.Set(other)
+        return MetaSet.Set(self.elements) - MetaSet.Set(other)
 
-class Relation:
+class Relation(metaclass = MetaSet):
     def __init__(self, name, types, values=set()):
         """
         Used by state variables
@@ -233,18 +235,31 @@ class Relation:
         self.values = values
 
     @classmethod
-    def possible_tuples(cls):
+    def possible_tuples(cls) -> set:
         domain_elements = [type.objects() for type in cls.types]
-        return [tup for tup in itertools.product(*domain_elements)]
+        return set([tup for tup in itertools.product(*domain_elements)])
+
+    # override "in" operator, e.g.,: other in self
+    def __contains__(self, other):
+        return  MetaSet.Set(other) in MetaSet.Set(self.values)
+
+    # override "+" operator, e.g.,: self + other
+    def __add__(self, other):
+        return MetaSet.Set(self.values) + MetaSet.Set(other)
+
+    # override "-" operator, e.g.,: self - other
+    def __sub__(self, other):
+        return MetaSet.Set(self.values) - MetaSet.Set(other)
+
 
 #end
-class Snapshot:
+class VariableTracker:
     """
-    A snapshot of the current status of the system. It contains all state variables.
-    It also maintains a history of all the snapshots that have happened so far.
+    A system variable state tracker. All dynamic variables are tracked here.
+    It also maintains a history of all dynamic variable snapshots that have occurred so far.
     """
     def __init__(self):
-        # --- Snapshot metadata ---
+        # --- Snapshots metadata ---
         self.history_of_changes = deque()   # History used for backtracking.
         self.changes = dict()               # Changes made in this snapshot.
         # TODO: [Code] Need to record the transitions taken. To avoid making the same transition twice during backtracking.
@@ -274,16 +289,20 @@ class Snapshot:
             self.__dict__[name] = value
 
 
-# --- Snapshot ---
-SS = Snapshot()
+# --- Variable Tracker Initialization ---
+# TODO: [Code] Consider changing the variable name SS.
+SS = VariableTracker()
 
 #if($signatures)
 # --- Signatures ---
 
     #foreach($sig in $signatures)
 class ${sig.Name}(Signature):
+        #if(${sig.getObjectNames()})
     atoms = {${sig.getObjectNames()}}
-
+        #else
+    atoms = set()
+        #end
 
     #end
 

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -161,7 +161,7 @@ class MetaSignature(type):
 
 
 class Signature(metaclass = MetaSignature):
-    def __init__(self, name, multiplicity):
+    def __init__(self, name, multiplicity, elements=set()):
         """
         Used by state variables
         - the member variables and functions will be used by state variables
@@ -173,7 +173,7 @@ class Signature(metaclass = MetaSignature):
         # for state variables:
         self.name = name
         self.multiplicity = multiplicity
-        self.elements = set()
+        self.elements = elements
         # TODO: delete this comment
         # Note: state variables are not implemented yet, this only aims to help in the future implementation of state variables
 
@@ -218,6 +218,20 @@ class Signature(metaclass = MetaSignature):
         return MetaSignature.Set(self.elements) - MetaSignature.Set(other)
 
 class Relation:
+    def __init__(self, name, types, values=set()):
+        """
+        Used by state variables
+        - the member variables and functions will be used by state variables
+
+        :param str name: the name of this state variable
+        :param list[string] types: the types of this state variable
+        :member set values: all the tuples in this instance (state variable)
+        """
+        # for state variables:
+        self.name = name
+        self.types = types
+        self.values = values
+
     @classmethod
     def possible_tuples(cls):
         domain_elements = [type.objects() for type in cls.types]

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -143,6 +143,13 @@ class MetaSet(type):
                 return cls - MetaSet.Set(other)
             return MetaSet.Set(cls._set.difference(other._set))
 
+        # override "*" operator as cartesian product
+        def __mul__(cls, other) -> set(tuple):
+            return set(itertools.product(cls._set, other._set))
+
+    def __iter__(cls):
+        return iter(cls.objects())
+
     # override "in" operator, e.g.,: other in cls
     def __contains__(cls, other):
         return  MetaSet.Set(other) in MetaSet.Set(cls.objects())
@@ -154,6 +161,10 @@ class MetaSet(type):
     # override "-" operator, e.g.,: cls - other
     def __sub__(cls, other):
         return MetaSet.Set(cls.objects()) - MetaSet.Set(other)
+
+    # override "*" operator as cartesian product
+    def __mul__(cls, other) -> set(tuple):
+        return MetaSet.Set(cls.objects()) * MetaSet.Set(other)
 
     # all objects in this static variable
     def objects(cls) -> set:
@@ -185,7 +196,7 @@ class Signature(metaclass = MetaSet):
 
     # Returns true if the new set of elements is valid for its multiplicity
     def is_valid(self, new_elements) -> bool:
-        length = len(self.elements)
+        length = len(new_elements)
         if self.multiplicity  == 0:  # Lone
             if(length != 0 and length != 1):
                 return False
@@ -221,7 +232,7 @@ class Signature(metaclass = MetaSet):
 
     # override "*" operator as cartesian product
     def __mul__(self, other) -> set(tuple):
-        return set(itertools.product(self.elements, other.elements))
+        return MetaSet.Set(self.elements) * MetaSet.Set(other)
 
 
 class Relation(metaclass = MetaSet):

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -385,12 +385,12 @@ $padding            return False
 $padding        if not ($trans.getGuardConditions().get(0)):
 $padding            return False
                 #else
-$padding        if not ($trans.getGuardConditions().get(0) and
+$padding        if not $trans.getGuardConditions().get(0)
                     #set($lastIndex = ${trans.getGuardConditions().size()} - 1)
                     #foreach($guardCondition in ${trans.getGuardConditions().subList(1, $lastIndex)})
-$padding                ${guardCondition} and
+$padding                ${guardCondition}
                     #end
-$padding                ${trans.getGuardConditions().get($lastIndex)}):
+$padding                ${trans.getGuardConditions().get($lastIndex)}:
 $padding            return False
                 #end
             #end

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -89,12 +89,9 @@ public class DashPythonTranslationTest {
             assertTrue(decl.contains("="));
         }
 
-        // Unamed relation should be generated.
-        assertTrue(translation.relations.contains(new DashPythonTranslation.Relation("Chair_Player", "[Chair, Player]")));
-
         assertTrue(gameState.getDecls().contains("Game_active_players = Player('active_players', 3)"));
         assertTrue(gameState.getDecls().contains("Game_active_chairs = Chair('active_chairs', 3)"));
-        assertTrue(gameState.getDecls().contains("Game_occupied = Chair_Player()"));
+        assertTrue(gameState.getDecls().contains("Game_occupied = Chair * Player"));
 
         for (String init : gameState.getInits()) {
             assertTrue(init.contains("="));

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -210,8 +210,8 @@ public class CoreDashToPythonTest {
                 "(not(SS.S_R_in_m1 in SS.S_R_med) and",
                 "SS.S_R_in_m1 in SS.S_R_med and",
                 "not(SS.S_R_in_m1 in SS.S_R_med))):",
-                "if not (not(SS.in_m1 * SS.in_m2 in SS.S_R_interactions) and", // add_relation
-                "not(SS.in_m2 * SS.in_m1 in SS.S_R_interactions) and",
+                "if not (not(SS.S_R_in_m1 * SS.S_R_in_m2 in SS.S_R_interactions) and", // add_relation
+                "not(SS.S_R_in_m2 * SS.S_R_in_m1 in SS.S_R_interactions) and",
                 "SS.S_R_in_m1 in SS.S_R_med and",
                 "SS.S_R_in_m2 in SS.S_R_med):"
         );

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -75,8 +75,6 @@ public class CoreDashToPythonTest {
                 "class LoneSig(Signature):",
                 "atoms = set()");
 
-        CoreDashToPython.print(translation);
-
         for(String sigTrans : expectedTranslation){
             // System.out.println("====== "+sigTrans);
             assert (CoreDashToPython.convert2String(translation).contains(sigTrans));
@@ -145,9 +143,9 @@ public class CoreDashToPythonTest {
         String dashModel = "sig Med {}\n" +
                 "conc state S {\n" +
                 "    default state R{\n" +
-                "        env in_m1: lone Med\n" +
+                "        env in_m1, in_m2: lone Med\n" +
                 "        med: set Med\n" +
-                "\n" +
+                "        interactions: Med -> set Med\n"+
                 "        trans add_med1 {\n" +
                 "            when {\n" +
                 "                (!(in_m1 in med) and !(in_m1 in med))\n" +
@@ -178,6 +176,14 @@ public class CoreDashToPythonTest {
                 "            }\n" +
                 "            do med' = med\n" +
                 "        }\n" +
+                "        trans add_relation {\n" +
+                "            when {\n" +
+                "                (!(in_m1 -> in_m2 in interactions) and !(in_m2 -> in_m1 in interactions))\n" +
+                "                in_m1 in med\n" +
+                "                in_m2 in med\n" +
+                "            }\n" +
+                "            do interactions' = interactions + {in_m1->in_m2 + in_m2->in_m1}\n" +
+                "        }\n"+
                 "    }\n" +
                 "}\n";
 
@@ -203,7 +209,12 @@ public class CoreDashToPythonTest {
                 "SS.S_R_in_m1 in SS.S_R_med or",
                 "(not(SS.S_R_in_m1 in SS.S_R_med) and",
                 "SS.S_R_in_m1 in SS.S_R_med and",
-                "not(SS.S_R_in_m1 in SS.S_R_med))):");
+                "not(SS.S_R_in_m1 in SS.S_R_med))):",
+                "if not (not(SS.in_m1 * SS.in_m2 in SS.S_R_interactions) and", // add_relation
+                "not(SS.in_m2 * SS.in_m1 in SS.S_R_interactions) and",
+                "SS.S_R_in_m1 in SS.S_R_med and",
+                "SS.S_R_in_m2 in SS.S_R_med):"
+        );
 
         String output = CoreDashToPython.convert2String(translation);
 

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -18,8 +18,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class CoreDashToPythonTest {
 
@@ -74,12 +73,12 @@ public class CoreDashToPythonTest {
                 "class SomeSig(Signature):",
                 "atoms = {\"SomeSig$0\", \"SomeSig$1\", \"SomeSig$2\"}",
                 "class LoneSig(Signature):",
-                "atoms = {}");
+                "atoms = set()");
 
         CoreDashToPython.print(translation);
 
         for(String sigTrans : expectedTranslation){
-            System.out.println("====== "+sigTrans);
+            // System.out.println("====== "+sigTrans);
             assert (CoreDashToPython.convert2String(translation).contains(sigTrans));
         }
     }
@@ -138,6 +137,78 @@ public class CoreDashToPythonTest {
 
         for(String trans : expectedTranslation){
             assert (CoreDashToPython.convert2String(translation).contains(trans));
+        }
+    }
+
+    @Test
+    public void test_GuardCondition_ConcatenationAndFormat_Correct() throws IOException {
+        String dashModel = "sig Med {}\n" +
+                "conc state S {\n" +
+                "    default state R{\n" +
+                "        env in_m1: lone Med\n" +
+                "        med: set Med\n" +
+                "\n" +
+                "        trans add_med1 {\n" +
+                "            when {\n" +
+                "                (!(in_m1 in med) and !(in_m1 in med))\n" +
+                "                in_m1 in med or in_m1 in med\n" +
+                "            }\n" +
+                "            do med' = med\n" +
+                "        }\n" +
+                "        trans add_med2 {\n" +
+                "            when (!(in_m1 in med) and !(in_m1 in med))\n" +
+                "            do med' = med\n" +
+                "        }\n" +
+                "        trans add_med3 {\n" +
+                "            when (in_m1 in med) and !(in_m1 in med)\n" +
+                "            do med' = med\n" +
+                "        }\n" +
+                "        trans add_med4 {\n" +
+                "            when {\n" +
+                "                (in_m1 in med) and !(in_m1 in med) or\n" +
+                "                (in_m1 in med) or !(in_m1 in med)\n" +
+                "            }\n" +
+                "            do med' = med\n" +
+                "        }\n" +
+                "        trans add_med5 {\n" +
+                "            when {\n" +
+                "                (in_m1 in med) and !(in_m1 in med) or\n" +
+                "                (in_m1 in med) or !(in_m1 in med) and\n" +
+                "                (in_m1 in med) and !(in_m1 in med)\n" +
+                "            }\n" +
+                "            do med' = med\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        dashModule = new DashToCoreDash().transformToCoreDash(dashModule, null, "");
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule, null);
+
+        List<String> expectedTranslation = Arrays.asList(
+                "if not (not(SS.S_R_in_m1 in SS.S_R_med) and",  // add_med1
+                "not(SS.S_R_in_m1 in SS.S_R_med) and",
+                "(SS.S_R_in_m1 in SS.S_R_med or",
+                "SS.S_R_in_m1 in SS.S_R_med)):",
+                "if not (not(SS.S_R_in_m1 in SS.S_R_med) and",  // add_med2
+                "not(SS.S_R_in_m1 in SS.S_R_med)):",
+                "if not (SS.S_R_in_m1 in SS.S_R_med and",       // add_med3
+                "not(SS.S_R_in_m1 in SS.S_R_med)):",
+                "if not ((SS.S_R_in_m1 in SS.S_R_med and",      // add_med4
+                "not(SS.S_R_in_m1 in SS.S_R_med)) or",
+                "SS.S_R_in_m1 in SS.S_R_med or",
+                "not(SS.S_R_in_m1 in SS.S_R_med)):",
+                "if not ((SS.S_R_in_m1 in SS.S_R_med and",      // add_med5
+                "not(SS.S_R_in_m1 in SS.S_R_med)) or",
+                "SS.S_R_in_m1 in SS.S_R_med or",
+                "(not(SS.S_R_in_m1 in SS.S_R_med) and",
+                "SS.S_R_in_m1 in SS.S_R_med and",
+                "not(SS.S_R_in_m1 in SS.S_R_med))):");
+
+        String output = CoreDashToPython.convert2String(translation);
+
+        for(String trans : expectedTranslation){
+            assert (output.contains(trans));
         }
     }
 }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -10,10 +10,7 @@ import edu.mit.csail.sdg.ast.ExprList;
 import edu.mit.csail.sdg.ast.ExprUnary;
 import edu.mit.csail.sdg.ast.ExprVar;
 
-import java.util.LinkedList;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 /*
@@ -27,21 +24,31 @@ public class DashExprToPython<ExprType> {
     private List<DashPythonTranslation.Relation> relations;
     public boolean isDecl = false;
     public boolean isInit = false;
+    private boolean isWhenExpr;
 
-    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations){
+    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations, boolean isWhenExpr){
         this.specialExpr = specialExpr;
         this.sbs = new LinkedList<>();
         this.sbs.addLast(new StringBuilder());
         this.variable2StateNameMap = variable2StateNameMap;
         this.varName = varName;
         this.relations = relations;
+        this.isWhenExpr = isWhenExpr;
 
         // TODO: currently only support DashWhenExpr
         this.parseExpr();
     }
 
+    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations){
+        this(specialExpr, variable2StateNameMap, varName, relations, false);
+    }
+
+    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, boolean isWhenExpr){
+        this(specialExpr, variable2StateNameMap, "", null, isWhenExpr);
+    }
+
     public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap){
-        this(specialExpr, variable2StateNameMap, "", null);
+        this(specialExpr, variable2StateNameMap, "", null, false);
     }
 
     @Override
@@ -51,14 +58,20 @@ public class DashExprToPython<ExprType> {
 
     public List<String> toList(){
         List<String> result = new LinkedList<>();
-        for (StringBuilder sb : sbs) {
-            if (sb.length() > 0){
-                result.add(sb.toString());
+        for (StringBuilder expr : sbs){
+            if (expr.length() == 0) {
+                continue;
+            }
+            // Concatenate to the previous expression.
+            if (expr.charAt(0) == ')' || expr.toString().equals(" or") || expr.toString().equals(" and")){
+                result.set(result.size() - 1, result.get(result.size() - 1).concat(expr.toString()));
+            }else{
+                result.add(expr.toString());
             }
         }
         return result;
     }
-    
+
     public void reparseExpr() {
         sbs.removeLast();
         sbs.addLast(new StringBuilder());
@@ -88,10 +101,32 @@ public class DashExprToPython<ExprType> {
         if (node instanceof  ExprList) {
             ExprList exprList = (ExprList) node;
             // Assuming each expr in the list is an independent statement
-            for (Expr subNode : exprList.args) {
-                sbs.getLast().append(genExpr(subNode, exprList.args.size()));
+            Iterator<Expr> subNode = exprList.args.iterator();
+
+            if (1 == exprList.args.size()){
+                sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
+                sbs.addLast(new StringBuilder());
+                return "";
+            }
+
+            if(isWhenExpr){ sbs.getLast().append("("); }
+            while (subNode.hasNext()) {
+                sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
+                // linkOperators
+                if(isWhenExpr){
+                    if (subNode.hasNext()){
+                        if (exprList.op == ExprList.Op.AND){
+                            sbs.getLast().append(" and");
+                        } else if (exprList.op == ExprList.Op.OR){
+                            sbs.getLast().append(" or");
+                        }
+                    }else{
+                        sbs.getLast().append(")");
+                    }
+                }
                 sbs.addLast(new StringBuilder());
             }
+
             return "";
         }else if (node instanceof ExprUnary) {
             // TODO: is sub always a binary?

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -183,7 +183,12 @@ public class DashExprToPython<ExprType> {
             // TODO: assume only 1 expression and it is an eval statement
             String quantifiedBody = genExpr(qtNode.sub, 1);
 
-            return quantifier + String.format("%s for %s in %s", quantifiedBody, localVarStack.pop(), quantifiedDecl) + "])";
+            String quantifiedVariable = "x";
+            if (!localVarStack.isEmpty()){
+//                quantifiedVariable = localVarStack.peekLast();
+            }
+
+            return quantifier + String.format("%s for %s in %s", quantifiedBody, quantifiedVariable, quantifiedDecl) + "])";
         } else {
             // under development, use this to catch more types that could be useful
             System.out.println("[Warning] Need more types: " + node.getClass());

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -260,11 +260,15 @@ public class DashExprToPython<ExprType> {
             	// TODO: currently only support relation for exactly 2 types
 
                 // Generate new relation name and add it to the list of relations.
-                String newRelationName = node.left + "_" + node.right;
-                String type = "[" + node.left + ", " + node.right  + "]";
-                DashPythonTranslation.Relation newRelation = new DashPythonTranslation.Relation(newRelationName, type);
-                if (relations != null && !relations.contains(newRelation)){ relations.add(newRelation); }
-                res = newRelationName + "()";
+                res = "SS." + node.left + " * SS." + node.right;
+
+                /* [Deprecated]: now the Alloy Solver will handle the initialization of relations
+                    String type = "[" + node.left + ", " + node.right  + "]";
+                    DashPythonTranslation.Relation newRelation = new DashPythonTranslation.Relation(newRelationName, type);
+                    if (relations != null && !relations.contains(newRelation)){ relations.add(newRelation); }
+                    res = newRelationName + "()";
+                 */
+
                 rightConsumed = true;
                 break;
             case ANY_ARROW_SOME:

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -2,13 +2,7 @@ package ca.uwaterloo.watform.rapidDash;
 
 import ca.uwaterloo.watform.ast.DashDoExpr;
 import ca.uwaterloo.watform.ast.DashWhenExpr;
-import edu.mit.csail.sdg.ast.Expr;
-import edu.mit.csail.sdg.ast.ExprBadJoin;
-import edu.mit.csail.sdg.ast.ExprBinary;
-import edu.mit.csail.sdg.ast.ExprConstant;
-import edu.mit.csail.sdg.ast.ExprList;
-import edu.mit.csail.sdg.ast.ExprUnary;
-import edu.mit.csail.sdg.ast.ExprVar;
+import edu.mit.csail.sdg.ast.*;
 
 import java.util.*;
 
@@ -25,9 +19,11 @@ public class DashExprToPython<ExprType> {
     public boolean isDecl = false;
     public boolean isInit = false;
     private boolean isWhenExpr;
+    private Deque<String> localVarStack;
 
     public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations, boolean isWhenExpr){
         this.specialExpr = specialExpr;
+        this.localVarStack = new LinkedList<>();
         this.sbs = new LinkedList<>();
         this.sbs.addLast(new StringBuilder());
         this.variable2StateNameMap = variable2StateNameMap;
@@ -115,11 +111,8 @@ public class DashExprToPython<ExprType> {
                 // linkOperators
                 if(isWhenExpr){
                     if (subNode.hasNext()){
-                        if (exprList.op == ExprList.Op.AND){
-                            sbs.getLast().append(" and");
-                        } else if (exprList.op == ExprList.Op.OR){
-                            sbs.getLast().append(" or");
-                        }
+                        if (exprList.op == ExprList.Op.AND){ sbs.getLast().append(" and"); }
+                        else if (exprList.op == ExprList.Op.OR){ sbs.getLast().append(" or"); }
                     }else{
                         sbs.getLast().append(")");
                     }
@@ -162,6 +155,35 @@ public class DashExprToPython<ExprType> {
             } else {
                 System.out.println("[Warning] BadNode needs more types: " + node.getClass());
             }
+        } else if (node instanceof ExprQt) {
+            // Expression with quantifiers
+            ExprQt qtNode = (ExprQt) node;
+
+            // Get the quantifier for list comprehension
+            String quantifier;
+            switch (qtNode.op) {
+                case ONE:
+                    quantifier = "any([";
+                    break;
+                default:
+                case ALL:
+                    quantifier = "all([";
+                    break;
+            }
+
+            // Get declaration of the quantified variable
+            // TODO: assume only 1 declaration
+            String quantifiedDecl = genExpr(qtNode.decls.get(0).expr, 1);
+
+            // Use a stack of local variables to keep track of the quantified variable names
+            // TODO: not exactly sure if this will always work
+            localVarStack.clear();
+
+            // Get the body of the quantifier
+            // TODO: assume only 1 expression and it is an eval statement
+            String quantifiedBody = genExpr(qtNode.sub, 1);
+
+            return quantifier + String.format("%s for %s in %s", quantifiedBody, localVarStack.pop(), quantifiedDecl) + "])";
         } else {
             // under development, use this to catch more types that could be useful
             System.out.println("[Warning] Need more types: " + node.getClass());
@@ -260,7 +282,7 @@ public class DashExprToPython<ExprType> {
             	// TODO: currently only support relation for exactly 2 types
 
                 // Generate new relation name and add it to the list of relations.
-                res = "SS." + node.left + " * SS." + node.right;
+                res = getVarName(node.left.toString()) + " * " + getVarName(node.right.toString());
 
                 /* [Deprecated]: now the Alloy Solver will handle the initialization of relations
                     String type = "[" + node.left + ", " + node.right  + "]";
@@ -444,6 +466,7 @@ public class DashExprToPython<ExprType> {
         if (variable2StateNameMap.containsKey(varName)){
             return "SS." + variable2StateNameMap.get(varName) + "_" + varName;
         }
+        localVarStack.addLast(varName);
     	return varName;
     }
 }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -804,7 +804,7 @@ public class DashPythonTranslation {
                 this.eventCondition = dashTrans.getTriggerEvent().getRawName();
             }
             if(dashTrans.getCondition() != null){    // determines the guard_condition (if statement)
-                DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap);
+                DashExprToPython dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap, true);
 
                 // set condition
                 this.guardConditions = dashExprTranslator.toList();

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -686,6 +686,9 @@ public class DashPythonTranslation {
                                 values = "{" + String.join(", ", atoms) + "}";
                             }
                         }
+                        if (values.equals("{}")) {
+                            values = "set()";
+                        }
                         statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + className + "('" + variableName + "', " + multiplicityOrTypes + ", " + values + ")");
                         found = true;
                         break;

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -512,29 +512,32 @@ public class DashPythonTranslation {
             addVariableDeclarations(state);
 
         	// add state variable initializations and constraints (inits and init_constraints)
-        	for(DashInit init: state.getInitialConds()) {
-        		for(Expr expr: init.getAllExpressions()) {
-        			// if the Dash init func is empty, there will be one expr that says "true"
-        			if(expr.toString().equals("true")) {
-        				continue;
-        			}
-        			DashExprToPython dashExprTranslator = new DashExprToPython<>(expr, variable2StateNameMap);
-        			// TODO: this (and DashExprToPython) needs to be cleaned up
-        			dashExprTranslator.isInit = true;
-        			dashExprTranslator.reparseExpr();
+            if (a4Solution == null) {
+                for(DashInit init: state.getInitialConds()) {
+                    for(Expr expr: init.getAllExpressions()) {
+                        // if the Dash init func is empty, there will be one expr that says "true"
+                        if(expr.toString().equals("true")) {
+                            continue;
+                        }
+                        DashExprToPython dashExprTranslator = new DashExprToPython<>(expr, variable2StateNameMap);
+                        // TODO: this (and DashExprToPython) needs to be cleaned up
+                        dashExprTranslator.isInit = true;
+                        dashExprTranslator.reparseExpr();
 
-        			// if the expression is a constraint on a variable's cardinality, add "assert"
-        			// TODO: are other initialization constraint types possible? They need to be handled here
-        			if(expr instanceof ExprBinary) {
-        				ExprBinary binaryNode = (ExprBinary) expr;
-        				if(binaryNode.left instanceof ExprUnary && ((ExprUnary)binaryNode.left).op == ExprUnary.Op.CARDINALITY) {
-        					this.statesMap.get(state.getFullyQualName()).addInitConstraint("assert " + dashExprTranslator.toString());
-        					continue;
-        				}
-        			}
-            		this.statesMap.get(state.getFullyQualName()).addInit(dashExprTranslator.toString());
-        		}
-        	}
+                        // if the expression is a constraint on a variable's cardinality, add "assert"
+                        // TODO: are other initialization constraint types possible? They need to be handled here
+                        if(expr instanceof ExprBinary) {
+                            ExprBinary binaryNode = (ExprBinary) expr;
+                            if(binaryNode.left instanceof ExprUnary && ((ExprUnary)binaryNode.left).op == ExprUnary.Op.CARDINALITY) {
+                                this.statesMap.get(state.getFullyQualName()).addInitConstraint("assert " + dashExprTranslator.toString());
+                                continue;
+                            }
+                        }
+                        this.statesMap.get(state.getFullyQualName()).addInit(dashExprTranslator.toString());
+                    }
+                }
+            }
+
 
         	// add state events
         	for(DashEvent event: state.getEvents()) {
@@ -627,15 +630,75 @@ public class DashPythonTranslation {
 
     // Declare state variables and add them into the map.
     private void addVariableDeclarations(DashSuperState state) {
+        Sig snapshot = null;
+        if (a4Solution != null) {
+            // Find Snapshot signature from a4Solution
+            for (Sig sigIter : a4Solution.getAllReachableSigs()) {
+                if (clean(sigIter.label).equals("Snapshot")) {
+                    snapshot = sigIter;
+                    break;
+                }
+            }
+        }
         for(Decl decl: state.getVariables()) {
 
             String stateName = state.getFullyQualName();
             String variableName = decl.get().toString();
             variable2StateNameMap.put(variableName, stateName);
 
-            DashExprToPython dashExprTranslator = new DashExprToPython<>(decl.expr, variable2StateNameMap, variableName, this.relations);
-            dashExprTranslator.isDecl = true;
-            statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + dashExprTranslator);
+            if (a4Solution != null) {
+                // Find Snapshot signature from a4Solution
+                boolean found = false;
+                for (Sig.Field f : snapshot.getFields()) {
+                    if (f.label.equals(stateName + "_" + variableName)) {
+                        String className = "Signature";
+                        String multiplicityOrTypes = "3";
+                        String values = "{}";
+                        for (Type.ProductType type : f.type()) {
+                            if (type.arity() == 2) {
+                                // Signature
+                                className = clean(type.get(1).label);
+                                List<String> atoms = new ArrayList<String>();
+                                for (A4Tuple atom: a4Solution.eval(f,0)) {
+                                    if (atom.atom(0).equals("Snapshot$0")) {
+                                        atoms.add("\"" + atom.atom(1) + "\"");
+                                    }
+                                }
+                                values = "{" + String.join(", ", atoms) + "}";
+                            } else {
+                                // Relation
+                                className = "Relation";
+                                List<String> typeStrings = new ArrayList<String>();
+                                for (int i = 1; i < type.arity(); i++) {
+                                    typeStrings.add(clean(type.get(i).label));
+                                }
+                                multiplicityOrTypes = "[" + String.join(", ", typeStrings) + "]";
+                                List<String> atoms = new ArrayList<String>();
+                                for (A4Tuple atom : a4Solution.eval(f, 0)) {
+                                    if (atom.atom(0).equals("Snapshot$0")) {
+                                        List<String> tuple = new ArrayList<String>();
+                                        for (int i = 1; i < atom.arity(); i++) {
+                                            tuple.add("\"" + atom.atom(i) + "\"");
+                                        }
+                                        atoms.add("(" + String.join(", ", tuple) + ")");
+                                    }
+                                }
+                                values = "{" + String.join(", ", atoms) + "}";
+                            }
+                        }
+                        statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + className + "('" + variableName + "', " + multiplicityOrTypes + ", " + values + ")");
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    throw new ErrorFatal("Cannot find state variable " + stateName + "_" + variableName + " in the solution");
+                }
+            } else {
+                DashExprToPython dashExprTranslator = new DashExprToPython<>(decl.expr, variable2StateNameMap, variableName, this.relations);
+                dashExprTranslator.isDecl = true;
+                statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + dashExprTranslator);
+            }
         }
     }
 


### PR DESCRIPTION
Changes:
1. Fixed an issue that empty set will be written as `{}` in python. Changed to `set()`.
2. Support operations between Relations.
3. Support operations between `Sig_A -> Sig_B` and Relations.
4. Support Relations in guard conditions (evaluations).
5. Support both `OR` and `AND` operators between expressions in guard conditions.
6. Support cartesian product between signatures. Used symbol `*` as a cartesian product operator.
7. Support basic expressions with quantifiers (`all` and `one`). Basic means simple in this context. 
   - That is, only one quantified variable, i.e., the variable `x` in `forall x in ...`
   - Only one quantified expression, i.e., the expression `expr` in `... | <expr>`
8. Fix assignments, assignments should only modify the values of the variables, instead of changing the variables. This is done by using the `__setattr__()` of `VariableTracker`.