### PR TITLE
Cleanup Events

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -506,7 +506,7 @@ class CentralController:
         self.concState.default_initialize()
         self.commands = {"help": self.printHelp, "execute": self.execute}
         #if(${allEnvEvents.size()}> 0)
-        self.possibleEvents = {"${allEnvEvents.get(0).getModifiedName()}"#foreach($event in ${allEnvEvents.subList(1, ${allEncEvents.size()})}), "$!{event.getModifiedName()}"#end}
+        self.possibleEvents = {"${allEnvEvents.get(0).getModifiedName()}"#foreach($event in ${allEnvEvents.subList(1, ${allEnvEvents.size()})}), "$!{event.getModifiedName()}"#end}
         #else
         self.possibleEvents = {}
         #end
@@ -533,7 +533,10 @@ class CentralController:
                 if possible_transitions:
                     chosen_transition = random.randint(0, len(possible_transitions) - 1)
                     possible_transitions[chosen_transition]()
-                    # if conc_state's active state changed (i.e. conc_state took a transition), prevent additional transitions (big step maximality)
+                    # prevent the current state from taking additional transitions if it is conc (big step maximality)
+                    if cur_state.is_conc:
+                        unused_conc_states.remove(cur_state)
+                    # if any other conc_state's active state changed (i.e. the conc_state took a transition), prevent additional transitions
                     for conc_state in unused_conc_states.copy():
                         if conc_state.get_active_child_state() != conc_state_to_active_child[conc_state]:
                             unused_conc_states.remove(conc_state)

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -26,6 +26,7 @@ public class DashPythonTranslation {
     public List<Signature> signatures;
     public List<Relation> relations;
     public List<Event> allEnvEvents = new ArrayList<Event>();
+    private HashSet<String> envEventNames = new HashSet<String>();
     public State rootState = null;
     private Map<String, State> statesMap;
 
@@ -422,7 +423,16 @@ public class DashPythonTranslation {
         return "";
     }
 
+    private void addEventToLists(DashEvent event, DashSuperState state) {
+        Event newEvent = new Event(event.getRawName(), event.getFullyQualName(), event.getType(), this.statesMap.get(state.getFullyQualName()));
+        if(newEvent.isEnvEvent && !envEventNames.contains(newEvent.getModifiedName())) {
+            envEventNames.add(newEvent.getModifiedName());
+            allEnvEvents.add(newEvent);
+        }
+    }
+
     public class Event {
+
     	private String name;
     	private String modifiedName;
     	private boolean isEnvEvent;
@@ -540,11 +550,7 @@ public class DashPythonTranslation {
 
         	// add state events
         	for(DashEvent event: state.getEvents()) {
-        		Event newEvent = new Event(event.getRawName(), event.getFullyQualName(), event.getType(), this.statesMap.get(state.getFullyQualName()));
-        		this.statesMap.get(newEvent);
-        		if(newEvent.isEnvEvent) {
-        			allEnvEvents.add(newEvent);
-        		}
+                addEventToLists(event, state);
         	}
 
             // add sub-states
@@ -565,6 +571,11 @@ public class DashPythonTranslation {
         for(DashState state: dashModule.getORStates().values()) {
             // add state variable declarations (decls)
             addVariableDeclarations(state);
+
+            // add state events
+            for(DashEvent event: state.getEvents()) {
+                addEventToLists(event, state);
+            }
 
             // add sub-states
             for(DashConcState substate: state.getInnerConcStates()) {


### PR DESCRIPTION
This PR makes some minor fixes to events:
- Fixed a typo in the template file that prevented more than one env event from appearing in the python code
- big step maximality is enforced even when a transition is taken that does not contain a "goto"
- Cleaned up code in DashPythonTranslation.java (added helper function)

Digital Watch is now fully functional