### PR TITLE
Implement Orthogonal Definition of Big Step Maximality

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -644,21 +644,46 @@ class CentralController:
         #end
 
     def handle_event(self):
-        unused_conc_states = {self.concState#foreach($value in $allStates)#if($value.getIsConc() && !$value.isRootState()), $value.getPythonVariableName()#end#end} # set of conc states that haven't taken a transition in this big step
-        conc_state_to_active_child = dict() # dictionary that maps each conc state to its active child at the start of this big step
-        for conc_state in unused_conc_states:
-            conc_state_to_active_child[conc_state] = conc_state.get_active_child_state()
-        prev_num_unused_conc_states = -1
+        # set of transitions that can still be taken in this big step
+        #if(${allTransitions.size()} > 0)
+        remaining_legal_transitions = {
+            #foreach($trans in ${allTransitions.subList(0, ${allTransitions.size()} - 1)})
+            ${trans.getPythonVariableStateName()}._trans_${trans.getTransName()},
+            #end
+            #if($allTransitions.size() > 0)
+            #set($lastTrans = ${allTransitions.get(${allTransitions.size()} - 1)})
+            ${lastTrans.getPythonVariableStateName()}._trans_${lastTrans.getTransName()}
+            #end
+        }
+        #else
+        remaining_legal_transitions = set()
+        #end
+        # set of pairs of transitions that are orthogonal to each other
+        # the two transitions in each pair can both be taken in a big step
+        #if(${orthogonalPairs.size()} > 0)
+        orthogonal_transition_pairs = {
+        #foreach($pair in ${orthogonalPairs.subList(0, ${orthogonalPairs.size()} - 1)})
+            (${pair.getFirstTransStateName()}._trans_${pair.getFirstTrans()}, ${pair.getSecondTransStateName()}._trans_${pair.getSecondTrans()}),
+            #end
+            #if($orthogonalPairs.size() > 0)
+            #set($lastPair = ${orthogonalPairs.get(${orthogonalPairs.size()} - 1)})
+            (${lastPair.getFirstTransStateName()}._trans_${lastPair.getFirstTrans()}, ${lastPair.getSecondTransStateName()}._trans_${lastPair.getSecondTrans()})
+            #end
+        }
+        #else
+        orthogonal_transition_pairs = set()
+        #end
+        prev_remaining_legal_transitions = -1
 
-        while len(unused_conc_states) > 0 and prev_num_unused_conc_states != len(unused_conc_states):
-            prev_num_unused_conc_states = len(unused_conc_states)
+        while len(remaining_legal_transitions) > 0 and prev_remaining_legal_transitions != len(remaining_legal_transitions):
+            prev_remaining_legal_transitions = len(remaining_legal_transitions)
             state_queue = [self.concState]
             while state_queue:
                 cur_state = state_queue.pop(0)
 
                 possible_transitions = []
                 for k, v in cur_state.transitions.items():
-                    if k():
+                    if v in remaining_legal_transitions and k():
                         possible_transitions.append(v)
 
                 # pick a random transition that satisfy the invariants
@@ -670,19 +695,17 @@ class CentralController:
                         break
 
                 # if any transitions are possible, take one at random
-                if has_valid_transitions:
-                    # prevent the current state from taking additional transitions if it is conc (big step maximality)
-                    if cur_state.is_conc:
-                        unused_conc_states.remove(cur_state)
-                    # if any other conc_state's active state changed (i.e. the conc_state took a transition), prevent additional transitions
-                    for conc_state in unused_conc_states.copy():
-                        if conc_state.get_active_child_state() != conc_state_to_active_child[conc_state]:
-                            unused_conc_states.remove(conc_state)
+                if possible_transitions:
+                    chosen_transition = possible_transitions[random.randint(0, len(possible_transitions) - 1)]
+                    chosen_transition()
+                    remaining_legal_transitions.remove(chosen_transition)
+                    for transition in remaining_legal_transitions.copy():
+                        if (chosen_transition, transition) not in orthogonal_transition_pairs and (transition, chosen_transition) not in orthogonal_transition_pairs:
+                            remaining_legal_transitions.remove(transition)
                 # add cur_state's conc state children to queue
                 elif cur_state._is_children_conc:
                     for conc_state in cur_state._children:
-                        if conc_state in unused_conc_states:
-                            state_queue.append(conc_state)
+                        state_queue.append(conc_state)
                 # add cur_state's active state to queue
                 elif cur_state.get_active_child_state() is not None:
                     state_queue.append(cur_state.get_active_child_state())

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -539,7 +539,6 @@ $padding        # TODO: global variables (signatures used in this state)
                 #foreach($globalVar in $globalVariables)
 $padding        global ${globalVar}
                 #end#end
-$padding        print(Blue + "Taking transition ${trans.getTransName()}" + Reset)
             #if(!$trans.getActions().isEmpty() && !$trans.getAssignedVarNames().isEmpty())
                 #if(!$trans.getInvariantNames().isEmpty()) #foreach($var in $trans.getAssignedVarNames())
 $padding        ${var}_tmp = SS.${var}
@@ -566,9 +565,7 @@ $padding            return False
                     #end
                 #end
             #end
-            #if(${trans.getTriggerEvent()})
-$padding        SS.activeEvents.add("${trans.getTriggerEvent()}")
-            #end
+$padding        print(Blue + "Taking transition ${trans.getTransName()}" + Reset)
 $padding        # Apply State Activeness Changes
                 #if($trans.getNonActiveStatesAfterTrans().size() > 0)
 $padding        # size = $trans.getNonActiveStatesAfterTrans().size()
@@ -686,18 +683,18 @@ class CentralController:
                     if v in remaining_legal_transitions and k():
                         possible_transitions.append(v)
 
-                # pick a random transition that satisfy the invariants
+                # pick a random transition that satisfies the invariants
                 random.shuffle(possible_transitions)
-                has_valid_transitions = False
+                chosen_transition = None
+                took_a_transition = False
                 for trans in possible_transitions:
                     if trans():
-                        has_valid_transitions = True
+                        chosen_transition = trans
+                        took_a_transition = True
                         break
 
-                # if any transitions are possible, take one at random
-                if possible_transitions:
-                    chosen_transition = possible_transitions[random.randint(0, len(possible_transitions) - 1)]
-                    chosen_transition()
+                # If a transition was taken, update the remaining legal transitions
+                if took_a_transition:
                     remaining_legal_transitions.remove(chosen_transition)
                     for transition in remaining_legal_transitions.copy():
                         if (chosen_transition, transition) not in orthogonal_transition_pairs and (transition, chosen_transition) not in orthogonal_transition_pairs:

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -671,6 +671,38 @@ public class DashPythonTranslation {
         return states;
     }
 
+    public List<Transition> getAllTransitions() {
+        List<Transition> transitions = new ArrayList<>();
+
+        for(State state: statesMap.values()) {
+            for(Transition t: state.transitions) {
+                transitions.add(t);
+            }
+        }
+        return transitions;
+    }
+
+    public List<OrthogonalTransitionPair> getOrthogonalPairs() {
+        List<OrthogonalTransitionPair> orthogonalTransitionPairs = new ArrayList<>();
+        List<Transition> transitions = getAllTransitions();
+
+        for(int t1Index = 0; t1Index < transitions.size(); t1Index++) {
+            Transition t1 = transitions.get(t1Index);
+            for(int t2Index = t1Index+1; t2Index < transitions.size(); t2Index++) {
+                Transition t2 = transitions.get(t2Index);
+                State t1Src = this.statesMap.get(t1.fromStateName.replace("/", "_"));
+                State t1Dest = this.statesMap.get(t1.toStateName.replace("/", "_"));
+                State t2Src = this.statesMap.get(t2.fromStateName.replace("/", "_"));
+                State t2Dest = this.statesMap.get(t2.toStateName.replace("/", "_"));
+
+                if(rootState.LCA(rootState.LCA(t1Src, t1Dest), rootState.LCA(t2Src, t2Dest)).isChildrenConc()) {
+                    orthogonalTransitionPairs.add(new OrthogonalTransitionPair(t1.transName, t2.transName, t1.getPythonVariableStateName(), t2.getPythonVariableStateName()));
+                }
+            }
+        }
+        return orthogonalTransitionPairs;
+    }
+
     // Declare state variables and add them into the map.
     private void addEnvVariableDeclarations() {
 
@@ -837,6 +869,36 @@ public class DashPythonTranslation {
         return signaturesSortedList;
     }
 
+    public class OrthogonalTransitionPair {
+        private String firstTransition;
+        private String secondTransition;
+        private String firstTransitionState;
+        private String secondTransitionState;
+
+        public OrthogonalTransitionPair(String f, String s, String fts, String sts) {
+            this.firstTransition = f;
+            this.secondTransition = s;
+            this.firstTransitionState = fts;
+            this.secondTransitionState = sts;
+        }
+
+        public String getFirstTrans() {
+            return firstTransition;
+        }
+
+        public String getSecondTrans() {
+            return secondTransition;
+        }
+
+        public String getFirstTransStateName() {
+            return firstTransitionState;
+        }
+
+        public String getSecondTransStateName() {
+            return secondTransitionState;
+        }
+    }
+
     public class State{
         private String stateName;                       // state name
         private List<Transition>  transitions;   // store the translated code for transitions
@@ -879,6 +941,10 @@ public class DashPythonTranslation {
         public void addEvent(Event e) { events.add(e); }
         public State getDefaultSubstate() {
         	return defaultSubstate != null ? defaultSubstate : substates.get(0);
+        }
+
+        public Boolean isChildrenConc() {
+            return substates.size() > 0 ? substates.get(0).getIsConc() : false;
         }
 
         /**
@@ -1044,6 +1110,7 @@ public class DashPythonTranslation {
 
         public String getTransName(){return transName;}
         public String getStateName(){return stateName;}
+        public String getPythonVariableStateName() {return "ref_" + stateName.toLowerCase();}
         public List<String> getGuardConditions(){return guardConditions;}
         public List<String> getActions(){return actions;}
         public List<String> getInvariantNames(){return invariants;}

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -690,10 +690,10 @@ public class DashPythonTranslation {
             Transition t1 = transitions.get(t1Index);
             for(int t2Index = t1Index+1; t2Index < transitions.size(); t2Index++) {
                 Transition t2 = transitions.get(t2Index);
-                State t1Src = this.statesMap.get(t1.fromStateName.replace("/", "_"));
-                State t1Dest = this.statesMap.get(t1.toStateName.replace("/", "_"));
-                State t2Src = this.statesMap.get(t2.fromStateName.replace("/", "_"));
-                State t2Dest = this.statesMap.get(t2.toStateName.replace("/", "_"));
+                State t1Src = this.statesMap.get(t1.fromStateName);
+                State t1Dest = this.statesMap.get(t1.toStateName);
+                State t2Src = this.statesMap.get(t2.fromStateName);
+                State t2Dest = this.statesMap.get(t2.toStateName);
 
                 if(rootState.LCA(rootState.LCA(t1Src, t1Dest), rootState.LCA(t2Src, t2Dest)).isChildrenConc()) {
                     orthogonalTransitionPairs.add(new OrthogonalTransitionPair(t1.transName, t2.transName, t1.getPythonVariableStateName(), t2.getPythonVariableStateName()));
@@ -1075,7 +1075,7 @@ public class DashPythonTranslation {
 
             // check keywords
             if(dashTrans.getOrigin() != null){    // determines which state this transition belongs to
-                this.fromStateName = dashTrans.getOrigin().getAllOrigins().get(0);
+                this.fromStateName = dashTrans.getOrigin().getAllOrigins().get(0).replace("/", "_");
             }
             if(dashTrans.getTriggerEvent() != null){    // determines the trigger event
                 this.eventCondition = dashTrans.getTriggerEvent().getRawName();

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/transform/CoreDashToPython.java
@@ -70,6 +70,8 @@ public class CoreDashToPython {
 
         // add events
         vc.put("allEnvEvents", dashPythonTranslation.allEnvEvents);
+        vc.put("orthogonalPairs", dashPythonTranslation.getOrthogonalPairs());
+        vc.put("allTransitions", dashPythonTranslation.getAllTransitions());
         
         vc.put("rootState", dashPythonTranslation.rootState);
 


### PR DESCRIPTION
This PR's changes:
- Implements the definition of Big Step Maximality as discussed in our meeting on Feb 27
- The handleEvent() now has a lookup table that contains all transition pairs that are orthogonal to each other
- handleEvent() also uses remaining_legal_transitions to keep track of which transitions are still allowed under the big step maximality rules

Orthogonal Big Step Maximality Definition:
- two transitions t1, t2 can be both taken in a big step if and only if t1 is orthogonal to t2
- t1 is orthogonal to t2 if the scope of t1 (Lowest Common Ancestor of that transition's src and dest states) is in a different concurrent region than the scope of t2
- We test if two transitions are orthogonal by checking if LCA(scope(t1), scope(t2)) is a parent of concurrent states
- A transition will always be in the same concurrent region as itself, so no transition can be taken multiple times in a big step

Picture of the lookup table for Bit Counter:
<img width="600" alt="Screen Shot 2023-03-06 at 12 27 29 AM" src="https://user-images.githubusercontent.com/41312803/223026761-6f263b1a-0bce-40c0-8c4f-80fcd1ce044f.png">

All the small models still work after these changes.
