### PR TITLE
Support (almost) all quantified expressions

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -550,8 +550,8 @@ $padding        ${action}
 $padding        if not $trans.getInvariantNames().get(0)():
                     #foreach($var in $trans.getAssignedVarNames())
 $padding            SS.${var} = ${var}_tmp
-$padding            return False
                     #end
+$padding            return False
                 #elseif($trans.getInvariantNames().size() > 1)
 $padding        if not ($trans.getInvariantNames().get(0)() and
                     #set($lastIndex = ${trans.getInvariantNames().size()} - 1)
@@ -561,8 +561,8 @@ $padding            ${invariantName}() and
 $padding            ${trans.getInvariantNames().get($lastIndex)}()):
                     #foreach($var in $trans.getAssignedVarNames())
 $padding            SS.${var} = ${var}_tmp
-$padding            return False
                     #end
+$padding            return False
                 #end
             #end
 $padding        print(Blue + "Taking transition ${trans.getTransName()}" + Reset)

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -260,4 +260,36 @@ public class CoreDashToPythonTest {
             assert (output.contains(trans));
         }
     }
+
+    @Test
+    public void test_QuantifiedExpressions_Correct() throws IOException {
+        String dashModel = "sig Patient {} sig Medication {} conc state EHealthSystem { medications: set Medication " +
+                "patients: set Patient prescriptions: Patient -> set Medication interactions: Medication -> set Medication " +
+                "invariant I_2_Types_1 { all m1, m2: medications, p: patients | m1 -> m2 in interactions and p in Patient}" +
+                "invariant I_2_Same_Type { all m1, m2: Medication | m1 -> m2 in interactions}" +
+                "invariant I_3_Same_type { all m1, m2, m3: Medication | m1 -> m2 in interactions and m2 -> m3 in interactions}" +
+                "invariant I_symmetry { all m1, m2: Medication | m1 -> m2  in interactions iff m2 -> m1 in interactions }" +
+                "invariant I_no_statement {all m: medications | not (m -> m in interactions)}" +
+                "invariant I_2_Types_2 { all m1, m2: medications, p: patients | m1 -> m2 in interactions => !((p -> m1 in prescriptions) and (p -> m2 in prescriptions))}" +
+                "trans add_interaction {do interactions' = interactions} init {no medications no prescriptions no patients no interactions}}";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        dashModule = new DashToCoreDash().transformToCoreDash(dashModule, null, "");
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule, null);
+
+        List<String> expectedTranslation = Arrays.asList(
+            "(all([(m1 * m2 in SS.EHealthSystem_interactions and p in Patient) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))",
+            "(all([m1 * m2 in SS.EHealthSystem_interactions for m1 in Medication for m2 in Medication]))",
+            "(all([(m1 * m2 in SS.EHealthSystem_interactions and m2 * m3 in SS.EHealthSystem_interactions) for m1 in Medication for m2 in Medication for m3 in Medication]))",
+            "(all([(m1 * m2 in SS.EHealthSystem_interactions) == (m2 * m1 in SS.EHealthSystem_interactions) for m1 in Medication for m2 in Medication]))",
+            "(all([not(m * m in SS.EHealthSystem_interactions) for m in SS.EHealthSystem_medications]))",
+            "(all([(p * m1 in SS.EHealthSystem_prescriptions and p * m2 in SS.EHealthSystem_prescriptions) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))"
+            );
+
+        String output = CoreDashToPython.convert2String(translation);
+
+        for(String trans : expectedTranslation){
+            assert (output.contains(trans));
+        }
+    }
 }

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -222,4 +222,42 @@ public class CoreDashToPythonTest {
             assert (output.contains(trans));
         }
     }
+
+    @Test
+    public void test_EqualSign_ConditionsAndActions_Correct() throws IOException {
+        String dashModel = "sig Medication {} conc state S {" +
+                "    env in_m1, in_m2: lone Medication" +
+                "    env in_m3: set Medication" +
+                "    m2, m1, m4: set Medication" +
+                "    m3: lone Medication" +
+                "    init {no in_m1 no in_m2 no in_m3 no m1 no m2 no m3 no m4}" +
+                "    invariant equal {in_m1 = in_m2 or m1 = m2 and in_m1 = in_m2 and in_m3 = in_m2}" +
+                "    trans t1 {when {in_m1 = in_m2 or" +
+                "            m1 = m2 and in_m1 = in_m2}" +
+                "        do{in_m1 = in_m2 + in_m1" +
+                "            m1' = m2 + m1 + m4}}" +
+                "    trans t2 {when {in_m1 + in_m3 = in_m2\n" +
+                "            m4 + m1 = m2 + m3} do{in_m2 = in_m1 + in_m2" +
+                "            m2' = m1}}}";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        dashModule = new DashToCoreDash().transformToCoreDash(dashModule, null, "");
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule, null);
+
+        List<String> expectedTranslation = Arrays.asList(
+                "SS.S_in_m1 = Medication",  // Equal sign in init
+                "SS.S_m2 = Medication",
+                "SS.S_in_m1 == SS.S_in_m2 or",  // Equal sign in guard 1
+                "(SS.S_m1 == SS.S_m2 and",
+                "SS.S_in_m1 == SS.S_in_m2))",
+                "SS.S_in_m1 = SS.S_in_m2 + SS.S_in_m1",  // Equal sign in action 1
+                "SS.S_m1 = SS.S_m2 + SS.S_m1 + SS.S_m4"
+        );
+
+        String output = CoreDashToPython.convert2String(translation);
+
+        for(String trans : expectedTranslation){
+            assert (output.contains(trans));
+        }
+    }
 }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -12,7 +12,7 @@ import java.util.*;
  */
 public class DashExprToPython<ExprType> {
     enum ExprTypeE {
-        DO, EVAL, DEFAULT
+        DO, PRED, DEFAULT
     }
     private final String varTrackerName = "SS.";
     private ExprTypeE exprType;
@@ -72,8 +72,8 @@ public class DashExprToPython<ExprType> {
                 continue;
             }
             // Concatenate to the previous expression.
-            if(ExprTypeE.EVAL == exprType){
-                // Format the evaluation expression.
+            if(ExprTypeE.PRED == exprType){
+                // Format the predicate.
                 if (expr.charAt(0) == ')') {
                     result.set(result.size() - 1, result.get(result.size() - 1).concat(trimmedExpr));
                 }else if(trimmedExpr.equals("or") || trimmedExpr.equals("and")){
@@ -104,7 +104,6 @@ public class DashExprToPython<ExprType> {
             DashWhenExpr exp = (DashWhenExpr)this.specialExpr;
             sbs.getLast().append(genExpr(exp.getExpr(), exp.getAllExpressions().size()));
         } else if (specialExpr instanceof DashDoExpr){
-            // TODO: Do expr should be different since actions are needed, not just evaluation statements
             DashDoExpr exp = (DashDoExpr)this.specialExpr;
             sbs.getLast().append(genExpr(exp.getExpr(), exp.getAllExpression().size()));
         } else {
@@ -128,8 +127,8 @@ public class DashExprToPython<ExprType> {
                 return "";
             }
 
-            // evaluation expr need to be wrapped in () and must be linked with and/or operators
-            if (ExprTypeE.EVAL == exprType) {
+            // predicates need to be wrapped in () and must be linked with and/or operators
+            if (ExprTypeE.PRED == exprType) {
                 sbs.getLast().append("(");
                 while (subNode.hasNext()) {
                     sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
@@ -202,7 +201,7 @@ public class DashExprToPython<ExprType> {
             localVarStack.clear();
 
             // Get the formula/condition of the quantified expression
-            // TODO: assume only 1 expression and it is an eval statement
+            // TODO: assume only 1 expression and it is an predicate statement
             String quantifiedCondition = genExpr(qtNode.sub, 1);
 
             String quantifiedVariable = "x";
@@ -320,7 +319,7 @@ public class DashExprToPython<ExprType> {
     // translate Binary operation, also returns the empty space
     private String BinaryOp2PythonOp(ExprBinary node){
         String res = " ";
-        boolean addParanthesis = node.right instanceof ExprBinary;
+        boolean shouldDddParenthesis = node.right instanceof ExprBinary;
         boolean rightConsumed = false;  // if the right expression is already parsed
         switch(node.op){
             case ARROW:     // State relation declaration
@@ -330,6 +329,7 @@ public class DashExprToPython<ExprType> {
                 // Generate new relation name and add it to the list of relations.
                 res = getVarName(node.left.toString()) + " * " + getVarName(node.right.toString());
 
+                // TODO: we assume the model can always be solved by Alloy Solver
                 /* [Deprecated]: now the Alloy Solver will handle the initialization of relations
                     String type = "[" + node.left + ", " + node.right  + "]";
                     DashPythonTranslation.Relation newRelation = new DashPythonTranslation.Relation(newRelationName, type);
@@ -424,17 +424,17 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case EQUALS:        // this part assumes inner expression is a signature instances and are comparable
-            	if(isInit) {    // TODO: this should be deprecated
+            	if(isInit) {    // TODO: this should be deprecated if we assume the Alloy Solver can always handle the initialization
             		res = this.genExpr(node.left, 1) + " = " + this.genExpr(node.right, 1).toLowerCase();
-            	} else {
-                    // Assumption: this is an assignment
+            	} else if (ExprTypeE.DO == exprType){
+                    // TODO: Assumption: actions only include simple assignments
                     String left = this.genExpr(node.left, 1).substring(varTrackerName.length());
+                    assignableVars.add(left);
             		res = varTrackerName + left + " = ";
-                    if(ExprTypeE.DO == exprType){
-                        assignableVars.add(left);
-                    }
-            	}
-                addParanthesis = false;
+            	} else {        // predicates
+                    res = this.genExpr(node.left, 1) + " == ";
+                }
+                shouldDddParenthesis = false;
                 break;
             case NOT_EQUALS:    // this part assumes inner expression is a signature instances and are comparable
                 res = this.genExpr(node.left, 1) + " != ";
@@ -504,11 +504,13 @@ public class DashExprToPython<ExprType> {
                 break;
         }
 
-        // add paranthesis for right node
-        if(addParanthesis){
-            res += "(" + this.genExpr(node.right, 1) + ")";
-        }else if (!rightConsumed){
-            res += this.genExpr(node.right, 1);
+        // add the right expression node
+        if (!rightConsumed){
+            if(shouldDddParenthesis) {
+                res += "(" + this.genExpr(node.right, 1) + ")";
+            }else{
+                res += this.genExpr(node.right, 1);
+            }
         }
         return res;
     }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -23,16 +23,13 @@ public class DashExprToPython<ExprType> {
     private List<DashPythonTranslation.Relation> relations;
     public boolean isDecl = false;
     public boolean isInit = false;
-    private Deque<String> localVarStack;
     // used to store the dynamic variables that are related to the current expression
     // only used for invariants
     private Set<String> relatedDynamicVars;
     private List<String> assignableVars;
-    private Set<String> reservedVarNames;
 
-    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations, ExprTypeE exprType, Set<String> reservedVarNames){
+    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations, ExprTypeE exprType){
         this.specialExpr = specialExpr;
-        this.localVarStack = new LinkedList<>();
         this.sbs = new LinkedList<>();
         this.sbs.addLast(new StringBuilder());
         this.variable2StateNameMap = variable2StateNameMap;
@@ -41,22 +38,21 @@ public class DashExprToPython<ExprType> {
         this.exprType = exprType;
         this.relatedDynamicVars = new HashSet<>();
         this.assignableVars = new LinkedList<>();
-        this.reservedVarNames = reservedVarNames;
 
         // TODO: currently only support DashWhenExpr
         this.parseExpr();
     }
 
     public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations){
-        this(specialExpr, variable2StateNameMap, varName, relations, ExprTypeE.DEFAULT, new HashSet<>());
+        this(specialExpr, variable2StateNameMap, varName, relations, ExprTypeE.DEFAULT);
     }
 
-    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, ExprTypeE exprType, Set<String> reservedVarNames){
-        this(specialExpr, variable2StateNameMap, "", null, exprType, reservedVarNames);
+    public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, ExprTypeE exprType){
+        this(specialExpr, variable2StateNameMap, "", null, exprType);
     }
 
     public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap){
-        this(specialExpr, variable2StateNameMap, "", null, ExprTypeE.DEFAULT, new HashSet<>());
+        this(specialExpr, variable2StateNameMap, "", null, ExprTypeE.DEFAULT);
     }
 
     @Override
@@ -189,46 +185,51 @@ public class DashExprToPython<ExprType> {
         } else if (node instanceof ExprQt) {
             // Expression with quantifiers
             ExprQt qtNode = (ExprQt) node;
+            StringBuilder quantifiedSource = new StringBuilder();
 
             // format: quantifier variable:type | formula
 
-            // Get type/declaration of the quantified variable
-            // TODO: assume only 1 declaration or type
-            String quantifiedDecl = genExpr(qtNode.decls.get(0).expr, 1);
+            for(Decl decl : qtNode.decls){
+                // Get type/declaration of the quantified variables
+                String quantifiedDecl = genExpr(decl.expr, 1);
 
-            // Use a stack of local variables to keep track of the quantified variable names
-            // TODO: not exactly sure if this will always work
-            localVarStack.clear();
-
-            // Get the formula/condition of the quantified expression
-            // TODO: assume only 1 expression and it is an predicate statement
-            String quantifiedCondition = genExpr(qtNode.sub, 1);
-
-            String quantifiedVariable = "x";
-            if (!localVarStack.isEmpty()){
-                quantifiedVariable = localVarStack.peekLast();
+                // Get the quantified variables
+                for (ExprHasName variable : decl.names) {
+                    if (quantifiedSource.length() > 0){
+                        quantifiedSource.append(" ");
+                    }
+                    quantifiedSource.append(String.format("for %s in %s", genExpr(variable, 1), quantifiedDecl));
+                }
             }
+            // Get the formula of the quantified expression
+            Deque<StringBuilder> sbsTemp = sbs;
+            this.sbs = new LinkedList<>();
+            this.sbs.addLast(new StringBuilder());
+            String quantifiedFormula = genExpr(qtNode.sub, 1);
+            // Meaning there are several statements in the quantified formula
+            if(!sbs.getFirst().toString().isEmpty()){
+                quantifiedFormula = String.join(" ", toList());
+            }
+            sbs = sbsTemp;
 
-            String quantifiedSource = String.format("for %s in %s", quantifiedVariable, quantifiedDecl);;
-
+            // TODO: SUM and COMPREHENSION needs further implementation, currently only support them with one variable
             // Get the quantifier for list comprehension
             switch (qtNode.op) {
                 case ALL:   // All true
-                    return String.format("all([%s %s])", quantifiedCondition, quantifiedSource);
+                    return String.format("all([%s %s])", quantifiedFormula, quantifiedSource);
                 case NO:    // No true
-                    return String.format("not any([%s %s])", quantifiedCondition, quantifiedSource);
+                    return String.format("not any([%s %s])", quantifiedFormula, quantifiedSource);
                 case LONE:  // one or no true
-                    return String.format("(1 >= [%s %s].count(True))", quantifiedCondition, quantifiedSource);
+                    return String.format("(1 >= [%s %s].count(True))", quantifiedFormula, quantifiedSource);
                 case ONE:   // exactly one true
-                    return String.format("(1 == [%s %s].count(True))", quantifiedCondition, quantifiedSource);
+                    return String.format("(1 == [%s %s].count(True))", quantifiedFormula, quantifiedSource);
                 case SOME:  // at least one true
-                    return String.format("any([%s %s])", quantifiedCondition, quantifiedSource);
+                    return String.format("any([%s %s])", quantifiedFormula, quantifiedSource);
                 case SUM:   // sum of values
-                    return String.format("sum([%s if %s else set() %s])", quantifiedVariable, quantifiedCondition, quantifiedSource);
+                    return String.format("sum([%s %s if %s])", qtNode.decls.get(0).names.get(0).toString(), quantifiedSource, quantifiedFormula);
                 case COMPREHENSION: // list comprehension
-                    return String.format("[%s if %s else set() %s]", quantifiedVariable, quantifiedCondition, quantifiedSource);
+                    return String.format("[%s %s if %s]", qtNode.decls.get(0).names.get(0).toString(), quantifiedSource, quantifiedFormula);
             }
-            // TODO: not sure if SUM and COMPREHENSION are correct
         } else {
             // under development, use this to catch more types that could be useful
             System.out.println("[Warning] Need more types: " + node.getClass());
@@ -488,7 +489,7 @@ public class DashExprToPython<ExprType> {
                 res = "(" + this.genExpr(node.left, 1) + ") or ";
                 break;
             case IFF:
-                res = " ";
+                res = "(" + this.genExpr(node.left, 1) + ") == ";
                 break;
             case UNTIL:
                 res = " ";
@@ -524,9 +525,6 @@ public class DashExprToPython<ExprType> {
         if (variable2StateNameMap.containsKey(varName)){
             relatedDynamicVars.add(varName);
             return varTrackerName + variable2StateNameMap.get(varName) + "_" + varName;
-        }
-        if (!reservedVarNames.contains(varName)){
-            localVarStack.addLast(varName);
         }
     	return varName;
     }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -609,21 +609,16 @@ public class DashPythonTranslation {
         	}
         }
 
-        // gather the names of all relations and signatures
-        Set<String> reservedNames = new HashSet<>();
-        signatures.forEach(sig -> reservedNames.add(sig.getName()));
-        relations.forEach(rel -> reservedNames.add(rel.getName()));
-
         // generate invariants
         invariants = new ArrayList<>();
         for(DashInvariant dashInv : dashModule.getInvariants().values()){
-            Invariant inv = new Invariant(dashInv, reservedNames);
+            Invariant inv = new Invariant(dashInv);
             invariants.add(inv);
         }
 
         // generate transitions
         for(DashTrans dashTrans : dashModule.getTransitions().values()){
-            Transition trans = new Transition(dashTrans, invariants, reservedNames);
+            Transition trans = new Transition(dashTrans, invariants);
             this.statesMap.get(trans.getStateName()).addTransition(trans);
             this.setTransStateActivenessChange(trans);
         }
@@ -1068,7 +1063,7 @@ public class DashPythonTranslation {
         public HashSet<State> nonActiveStatesAfterTrans = new HashSet<State>();
         public HashSet<State> activeStatesAfterTrans = new HashSet<State>();
 
-        public Transition(DashTrans dashTrans, List<Invariant> invariantList, Set<String> reservedNames){
+        public Transition(DashTrans dashTrans, List<Invariant> invariantList){
             // set default transition information
             this.transName = dashTrans.getRawName();
             if (dashTrans.getParent() instanceof DashConcState) {
@@ -1085,11 +1080,11 @@ public class DashPythonTranslation {
                 this.eventCondition = dashTrans.getTriggerEvent().getRawName();
             }
             if(dashTrans.getCondition() != null){       // determines the guard_condition (if statement)
-                DashExprToPython<DashWhenExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED, reservedNames);
+                DashExprToPython<DashWhenExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED);
                 this.guardConditions = dashExprTranslator.toList();
             }
             if(dashTrans.getAction() != null){  // determines the action
-                DashExprToPython<DashDoExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap,DashExprToPython.ExprTypeE.DO, reservedNames);
+                DashExprToPython<DashDoExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap,DashExprToPython.ExprTypeE.DO);
 
                 this.actions = dashExprTranslator.toList();
                 this.assignableVars = dashExprTranslator.getAssignableVars();
@@ -1147,13 +1142,13 @@ public class DashPythonTranslation {
         private List<String> conditions = new ArrayList<>();    // the logic for this invariant to be executed
         private Set<String> relatedVariables = new HashSet<>(); // the variables that are related to this invariant
 
-        public Invariant(DashInvariant dashInvariant, Set<String> reservedVarNames){
+        public Invariant(DashInvariant dashInvariant){
             // set default invariant information
             this.invariantName = "Inv_" + dashInvariant.getRawName();
 
             // determines the invariant condition
             if(dashInvariant.getExpr() != null){
-                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED, reservedVarNames);
+                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED);
                 this.conditions = dashExprTranslator.toList();
                 this.relatedVariables = dashExprTranslator.getRelatedDynamicVars();
             }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -541,6 +541,7 @@ public class DashPythonTranslation {
         	// add state variable declarations (decls)
             addVariableDeclarations(state);
 
+            // TODO: this should be deprecated if we assume the Alloy Solver can always handle the initialization
         	// add state variable initializations and constraints (inits and init_constraints)
             if (a4Solution == null) {
                 for(DashInit init: state.getInitialConds()) {
@@ -778,67 +779,70 @@ public class DashPythonTranslation {
                 }
             }
         }
+
+        // add the state variables
         for(Decl decl: state.getVariables()) {
+            for (ExprHasName var : decl.names) {
+                String stateName = state.getFullyQualName();
+                String variableName = var.toString();
+                variable2StateNameMap.put(variableName, stateName);
 
-            String stateName = state.getFullyQualName();
-            String variableName = decl.get().toString();
-            variable2StateNameMap.put(variableName, stateName);
-
-            if (a4Solution != null) {
-                // Find Snapshot signature from a4Solution
-                boolean found = false;
-                for (Sig.Field f : snapshot.getFields()) {
-                    if (f.label.equals(stateName + "_" + variableName)) {
-                        String className = "Signature";
-                        String multiplicityOrTypes = "3";
-                        String values = "{}";
-                        for (Type.ProductType type : f.type()) {
-                            if (type.arity() == 2) {
-                                // Signature
-                                className = clean(type.get(1).label);
-                                List<String> atoms = new ArrayList<String>();
-                                for (A4Tuple atom: a4Solution.eval(f,0)) {
-                                    if (atom.atom(0).equals("Snapshot$0")) {
-                                        atoms.add("\"" + atom.atom(1) + "\"");
-                                    }
-                                }
-                                values = "{" + String.join(", ", atoms) + "}";
-                            } else {
-                                // Relation
-                                className = "Relation";
-                                List<String> typeStrings = new ArrayList<String>();
-                                for (int i = 1; i < type.arity(); i++) {
-                                    typeStrings.add(clean(type.get(i).label));
-                                }
-                                multiplicityOrTypes = "[" + String.join(", ", typeStrings) + "]";
-                                List<String> atoms = new ArrayList<String>();
-                                for (A4Tuple atom : a4Solution.eval(f, 0)) {
-                                    if (atom.atom(0).equals("Snapshot$0")) {
-                                        List<String> tuple = new ArrayList<String>();
-                                        for (int i = 1; i < atom.arity(); i++) {
-                                            tuple.add("\"" + atom.atom(i) + "\"");
+                if (a4Solution != null) {
+                    // Find Snapshot signature from a4Solution
+                    boolean found = false;
+                    for (Sig.Field f : snapshot.getFields()) {
+                        if (f.label.equals(stateName + "_" + variableName)) {
+                            String className = "Signature";
+                            String multiplicityOrTypes = "3";
+                            String values = "{}";
+                            for (Type.ProductType type : f.type()) {
+                                if (type.arity() == 2) {
+                                    // Signature
+                                    className = clean(type.get(1).label);
+                                    List<String> atoms = new ArrayList<String>();
+                                    for (A4Tuple atom : a4Solution.eval(f, 0)) {
+                                        if (atom.atom(0).equals("Snapshot$0")) {
+                                            atoms.add("\"" + atom.atom(1) + "\"");
                                         }
-                                        atoms.add("(" + String.join(", ", tuple) + ")");
                                     }
+                                    values = "{" + String.join(", ", atoms) + "}";
+                                } else {
+                                    // Relation
+                                    className = "Relation";
+                                    List<String> typeStrings = new ArrayList<String>();
+                                    for (int i = 1; i < type.arity(); i++) {
+                                        typeStrings.add(clean(type.get(i).label));
+                                    }
+                                    multiplicityOrTypes = "[" + String.join(", ", typeStrings) + "]";
+                                    List<String> atoms = new ArrayList<String>();
+                                    for (A4Tuple atom : a4Solution.eval(f, 0)) {
+                                        if (atom.atom(0).equals("Snapshot$0")) {
+                                            List<String> tuple = new ArrayList<String>();
+                                            for (int i = 1; i < atom.arity(); i++) {
+                                                tuple.add("\"" + atom.atom(i) + "\"");
+                                            }
+                                            atoms.add("(" + String.join(", ", tuple) + ")");
+                                        }
+                                    }
+                                    values = "{" + String.join(", ", atoms) + "}";
                                 }
-                                values = "{" + String.join(", ", atoms) + "}";
                             }
+                            if (values.equals("{}")) {
+                                values = "set()";
+                            }
+                            statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + className + "('" + variableName + "', " + multiplicityOrTypes + ", " + values + ")");
+                            found = true;
+                            break;
                         }
-                        if (values.equals("{}")) {
-                            values = "set()";
-                        }
-                        statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + className + "('" + variableName + "', " + multiplicityOrTypes + ", " + values + ")");
-                        found = true;
-                        break;
                     }
+                    if (!found) {
+                        throw new ErrorFatal("Cannot find state variable " + stateName + "_" + variableName + " in the solution");
+                    }
+                } else {
+                    DashExprToPython dashExprTranslator = new DashExprToPython<>(decl.expr, variable2StateNameMap, variableName, this.relations);
+                    dashExprTranslator.isDecl = true;
+                    statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + dashExprTranslator);
                 }
-                if (!found) {
-                    throw new ErrorFatal("Cannot find state variable " + stateName + "_" + variableName + " in the solution");
-                }
-            } else {
-                DashExprToPython dashExprTranslator = new DashExprToPython<>(decl.expr, variable2StateNameMap, variableName, this.relations);
-                dashExprTranslator.isDecl = true;
-                statesMap.get(stateName).addDecl(stateName + "_" + variableName + " = " + dashExprTranslator);
             }
         }
     }
@@ -1081,7 +1085,7 @@ public class DashPythonTranslation {
                 this.eventCondition = dashTrans.getTriggerEvent().getRawName();
             }
             if(dashTrans.getCondition() != null){       // determines the guard_condition (if statement)
-                DashExprToPython<DashWhenExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap, DashExprToPython.ExprTypeE.EVAL, reservedNames);
+                DashExprToPython<DashWhenExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED, reservedNames);
                 this.guardConditions = dashExprTranslator.toList();
             }
             if(dashTrans.getAction() != null){  // determines the action
@@ -1149,7 +1153,7 @@ public class DashPythonTranslation {
 
             // determines the invariant condition
             if(dashInvariant.getExpr() != null){
-                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.EVAL, reservedVarNames);
+                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED, reservedVarNames);
                 this.conditions = dashExprTranslator.toList();
                 this.relatedVariables = dashExprTranslator.getRelatedDynamicVars();
             }


### PR DESCRIPTION
Changes:
- Fix Equal signs, equal signs in predicates will be translated to `==`
- Allow init of multiple variables with the same type (e.g., `m1, m2: Medication`), which was going to cause exceptions
- Translated operator `iff` to `==`
- Quantified expression
   - Allow multiple variables with the same type
   - Allow multiple variables with different types
   - Allow multiple formulas
 
Hopefully, the most common types of quantified expressions are supported now.  
Known issues:
- quantified expressions with the type `SUM` and `COMPREHENSION` are not fully supported. However, I have never seen any examples of them.


Sample, dash model:
```
sig Patient {}
sig Medication {}

conc state EHealthSystem {
    medications: set Medication
    patients: set Patient
    prescriptions: Patient -> set Medication
    interactions: Medication -> set Medication

    invariant I_2_Types_1 {
        all m1, m2: medications, p: patients |
            m1 -> m2 in interactions and p in Patient}
    invariant I_2_Same_Type { all m1, m2: Medication | m1 -> m2 in interactions}
    invariant I_3_Same_type { all m1, m2, m3: Medication | m1 -> m2 in interactions and m2 -> m3 in interactions}
    invariant I_symmetry { all m1, m2: Medication | m1 -> m2  in interactions iff m2 -> m1 in interactions }
    invariant I_no_statement {all m: medications | not (m -> m in interactions)}
    invariant I_2_Types_2 {
        all m1, m2: medications, p: patients |
            m1 -> m2 in interactions => !((p -> m1 in prescriptions) and (p -> m2 in prescriptions))}
    invariant I_2_exprs {
        all m: medications | not (m -> m in interactions)
        all m1, m2: medications, p: patients |
            m1 -> m2 in interactions => !((p -> m1 in prescriptions) and (p -> m2 in prescriptions))}

    trans add_interaction {
        do interactions' = interactions
    }

    init {
        no medications
        no prescriptions
        no patients
        no interactions
    }
}
```
Translated these invariants to:
```
def Inv_I_2_Types_1() -> bool:
    return (all([(m1 * m2 in SS.EHealthSystem_interactions and p in Patient) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))

def Inv_I_2_Same_Type() -> bool:
    return (all([m1 * m2 in SS.EHealthSystem_interactions for m1 in Medication for m2 in Medication]))

def Inv_I_3_Same_type() -> bool:
    return (all([(m1 * m2 in SS.EHealthSystem_interactions and m2 * m3 in SS.EHealthSystem_interactions) for m1 in Medication for m2 in Medication for m3 in Medication]))

def Inv_I_symmetry() -> bool:
    return (all([(m1 * m2 in SS.EHealthSystem_interactions) == (m2 * m1 in SS.EHealthSystem_interactions) for m1 in Medication for m2 in Medication]))

def Inv_I_no_statement() -> bool:
    return (all([not(m * m in SS.EHealthSystem_interactions) for m in SS.EHealthSystem_medications]))

def Inv_I_2_Types_2() -> bool:
    return (all([(p * m1 in SS.EHealthSystem_prescriptions and p * m2 in SS.EHealthSystem_prescriptions) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))

def Inv_I_2_exprs() -> bool:
    return (all([not(m * m in SS.EHealthSystem_interactions) for m in SS.EHealthSystem_medications]) and
        all([(p * m1 in SS.EHealthSystem_prescriptions and p * m2 in SS.EHealthSystem_prescriptions) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))
```