### PR TITLE
Simple PR to support some more set operators

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -145,6 +145,9 @@ class MetaSet(type):
             else:
                 print("Exception, unsupported type in MetaSet::Set: %s", type(initvalue))
 
+        def __len__(self):
+            return len(self._set)
+
         def __iter__(self):
             return iter(self._set)
 
@@ -172,6 +175,9 @@ class MetaSet(type):
         # override "*" operator as cartesian product
         def __mul__(cls, other) -> set(tuple):
             return set(itertools.product(cls._set, other._set))
+
+    def __len__(cls):
+        return len(cls.objects())
 
     def __iter__(cls):
         return iter(cls.objects())
@@ -260,6 +266,9 @@ class Signature(metaclass = MetaSet):
         else: # Set
             return random_subset(self.atoms)
 
+    def __len__(self) -> int:
+        return len(self.elements)
+
     def __iter__(self) -> iter:
         return iter(self.elements)
 
@@ -329,6 +338,9 @@ class Relation(metaclass = MetaSet):
             self.values = new_values
             return True
         return False
+
+    def __len__(self) -> int:
+        return len(self.values)
 
     def __iter__(self) -> iter:
         return iter(self.values)

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -292,4 +292,44 @@ public class CoreDashToPythonTest {
             assert (output.contains(trans));
         }
     }
+
+    @Test
+    public void test_Quantifers_Correct() throws IOException {
+        String dashModel = "sig Patient {} sig Medication {} conc state EHealthSystem {patients: set Patient\ninteractions: Medication -> set Medication\n" +
+                "trans interaction_test_1 {\n" +
+                "when{no interactions\n" +
+                "some interactions\n" +
+                "lone interactions\n" +
+                "one interactions}\n" +
+                "do interactions' = interactions}" +
+                "trans interaction_test_2 {\n" +
+                "when{no patients\n" +
+                "some patients\n" +
+                "lone patients\n" +
+                "one patients}\n" +
+                "do interactions' = interactions}}";
+
+        DashModule dashModule = DashUtil.parseEverything_fromStringDash(A4Reporter.NOP, dashModel);
+        dashModule = new DashToCoreDash().transformToCoreDash(dashModule, null, "");
+        DashPythonTranslation translation = new DashPythonTranslation(dashModule, null);
+
+        List<String> expectedTranslation = Arrays.asList(
+                "not bool(SS.EHealthSystem_interactions)",
+                "bool(SS.EHealthSystem_interactions)",
+                "(1 >= len(SS.EHealthSystem_interactions))",
+                "(1 == len(SS.EHealthSystem_interactions))",
+                "not bool(SS.EHealthSystem_patients)",
+                "bool(SS.EHealthSystem_patients)",
+                "(1 >= len(SS.EHealthSystem_patients))",
+                "(1 == len(SS.EHealthSystem_patients))"
+        );
+
+
+        String output = CoreDashToPython.convert2String(translation);
+        System.out.println(output);
+
+        for(String trans : expectedTranslation){
+            assert (output.contains(trans));
+        }
+    }
 }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -160,8 +160,9 @@ public class DashExprToPython<ExprType> {
             return BinaryOp2PythonOp((ExprBinary) node);
         } else if (node instanceof ExprVar || node instanceof ExprConstant){
             String varName = node.toString();
-            if('\'' == node.toString().charAt(node.toString().length() - 1)){
-                varName = node.toString().substring(0, node.toString().length() - 1);
+            if('\'' == varName.charAt(varName.length() - 1)){   // primed variable
+                varName = varName.substring(0, varName.length() - 1);
+                assignableVars.add(varName);
             }
 			return getVarName(varName);
         } else if (node instanceof ExprBadJoin) {
@@ -278,21 +279,22 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case NO:        // this part assumes the inner expression is a signature instance that is an object
-                res = this.genExpr(node,1) + " is None";
+                res = "not bool(" + this.genExpr(node,1) + ")";
                 break;
             case SOME:      // this part assumes the inner expression is a signature instance that is an object
-                res = this.genExpr(node,1) + " is not None";
+                res = "bool(" + this.genExpr(node,1) + ")";
                 break;
             case LONE:
-                res = " ";
+                res = "(1 >= len(" + this.genExpr(node,1) + "))";
                 break;
             case ONE:
-                res = " ";
+                res = "(1 == len(" + this.genExpr(node,1) + "))";
                 break;
             case TRANSPOSE:
                 res = " ";
                 break;
             case PRIME:
+                // TODO: don't think we need this
                 res = " ";
                 break;
             case RCLOSURE:
@@ -428,10 +430,8 @@ public class DashExprToPython<ExprType> {
             	if(isInit) {    // TODO: this should be deprecated if we assume the Alloy Solver can always handle the initialization
             		res = this.genExpr(node.left, 1) + " = " + this.genExpr(node.right, 1).toLowerCase();
             	} else if (ExprTypeE.DO == exprType){
-                    // TODO: Assumption: actions only include simple assignments
-                    String left = this.genExpr(node.left, 1).substring(varTrackerName.length());
-                    assignableVars.add(left);
-            		res = varTrackerName + left + " = ";
+                    // TODO: delete this part if we assume the Alloy Solver can always handle the initialization
+            		res = varTrackerName + this.genExpr(node.left, 1).substring(varTrackerName.length()) + " = ";
             	} else {        // predicates
                     res = this.genExpr(node.left, 1) + " == ";
                 }


### PR DESCRIPTION
Changes:
- Support more operators on sets. Cardinality check? (`lone`, `one`, `some`, `no`)
- Invariants are now based on prime variables instead of the variable of the LHS of the equal sign.
   - I.e., removed the assumption that we are using simple assignments when extracting the assignable variables in actions.