### PR TITLE
Kent/simple runtime solver

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -652,7 +652,7 @@ $padding        try:
                 #foreach($var in $trans.getAssignedVarNames())
                     #set($padding = "$padding$tab")
 $padding        for ${var}_updated in SS.${var}.possible_next_values():
-$padding            ${var}_updated = MetaSet.Set(${var}_updated)
+$padding            ${var}_updated = MetaSet.Set(set(${var}_updated))
                 #end
                 #if($trans.getActions().size() == 1)
 $padding            if $trans.getActions().get(0):

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -114,7 +114,7 @@ def random_subset(s):
 
 def powerset(iterable):
     s = list(iterable)
-    return MetaSet.Set(list(itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1))))
+    return set(itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1)))
 
 class MultiLevelExit(Exception):
     "Exception type used to perform multi level exit"
@@ -159,7 +159,7 @@ class MetaSet(type):
             return len(cls._set)
 
         def __iter__(cls):
-            return iter([MetaSet.Set(set(x)) for x in cls._set])
+            return iter(cls._set)
 
         def __repr__(cls):
             return str(cls._set)
@@ -320,10 +320,11 @@ class Signature(metaclass = MetaSet):
         elif self.multiplicity == Multiplicity.One:
             ret = [set(i) for i in self.atoms]
         elif self.multiplicity == Multiplicity.Some:
-            ret = powerset(self.atoms) - set(set())
+            ret = list(powerset(self.atoms) - set(set()))
         else: # Set
-            ret = powerset(self.atoms)
-        return MetaSet.Set(ret)
+            ret = list(powerset(self.atoms))
+        random.shuffle(ret)
+        return ret
 
     def __len__(self) -> int:
         return len(self.elements)
@@ -383,7 +384,9 @@ class Relation(metaclass = MetaSet):
         return random_subset(self.possible_tuples())
 
     def possible_next_values(self):
-        return powerset(self.possible_tuples())
+        ret = list(powerset(self.possible_tuples_instance_method()))
+        random.shuffle(ret)
+        return ret
 
     # Returns true if the new set of tuples is valid for its types
     def is_valid(self, values) -> bool:
@@ -649,6 +652,7 @@ $padding        try:
                 #foreach($var in $trans.getAssignedVarNames())
                     #set($padding = "$padding$tab")
 $padding        for ${var}_updated in SS.${var}.possible_next_values():
+$padding            ${var}_updated = MetaSet.Set(${var}_updated)
                 #end
                 #if($trans.getActions().size() == 1)
 $padding            if $trans.getActions().get(0):

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -114,7 +114,7 @@ def random_subset(s):
 
 def powerset(iterable):
     s = list(iterable)
-    return MetaSet.Set(itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1)))
+    return MetaSet.Set(list(itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1))))
 
 class MultiLevelExit(Exception):
     "Exception type used to perform multi level exit"
@@ -320,9 +320,9 @@ class Signature(metaclass = MetaSet):
         elif self.multiplicity == Multiplicity.One:
             ret = [set(i) for i in self.atoms]
         elif self.multiplicity == Multiplicity.Some:
-            ret = list(powerset(self.atoms) - set(set()))
+            ret = powerset(self.atoms) - set(set())
         else: # Set
-            ret = list(powerset(self.atoms))
+            ret = powerset(self.atoms)
         return MetaSet.Set(ret)
 
     def __len__(self) -> int:
@@ -383,7 +383,7 @@ class Relation(metaclass = MetaSet):
         return random_subset(self.possible_tuples())
 
     def possible_next_values(self):
-        return MetaSet.Set(powerset(self.possible_tuples()))
+        return powerset(self.possible_tuples())
 
     # Returns true if the new set of tuples is valid for its types
     def is_valid(self, values) -> bool:

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -114,7 +114,7 @@ def random_subset(s):
 
 def powerset(iterable):
     s = list(iterable)
-    return set(itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1)))
+    return MetaSet.Set(itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s)+1)))
 
 class MultiLevelExit(Exception):
     "Exception type used to perform multi level exit"
@@ -323,7 +323,6 @@ class Signature(metaclass = MetaSet):
             ret = list(powerset(self.atoms) - set(set()))
         else: # Set
             ret = list(powerset(self.atoms))
-        random.shuffle(ret)
         return MetaSet.Set(ret)
 
     def __len__(self) -> int:
@@ -384,9 +383,7 @@ class Relation(metaclass = MetaSet):
         return random_subset(self.possible_tuples())
 
     def possible_next_values(self):
-        ret = list(powerset(self.possible_tuples()))
-        random.shuffle(ret)
-        return MetaSet.Set(ret)
+        return MetaSet.Set(powerset(self.possible_tuples()))
 
     # Returns true if the new set of tuples is valid for its types
     def is_valid(self, values) -> bool:

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -159,7 +159,7 @@ class MetaSet(type):
             return len(cls._set)
 
         def __iter__(cls):
-            return iter(cls._set)
+            return iter([MetaSet.Set(set(x)) for x in cls._set])
 
         def __repr__(cls):
             return str(cls._set)
@@ -213,7 +213,7 @@ class MetaSet(type):
         return len(cls.objects())
 
     def __iter__(cls):
-        return iter(cls.objects())
+        return iter(MetaSet.Set(cls.objects()))
 
     def __repr__(cls) -> str:
         return f"{cls.__name__}: " + f"{cls.objects()}" if cls.objects() else "Empty"
@@ -324,13 +324,13 @@ class Signature(metaclass = MetaSet):
         else: # Set
             ret = list(powerset(self.atoms))
         random.shuffle(ret)
-        return ret
+        return MetaSet.Set(ret)
 
     def __len__(self) -> int:
         return len(self.elements)
 
     def __iter__(self) -> iter:
-        return iter(self.elements)
+        return iter(MetaSet.Set(self.elements))
 
     def __repr__(self):
         return f"{self.__class__.__name__} - {self.name} : " + f"{self.elements}" if self.elements else "Empty"
@@ -386,7 +386,7 @@ class Relation(metaclass = MetaSet):
     def possible_next_values(self):
         ret = list(powerset(self.possible_tuples()))
         random.shuffle(ret)
-        return ret
+        return MetaSet.Set(ret)
 
     # Returns true if the new set of tuples is valid for its types
     def is_valid(self, values) -> bool:
@@ -409,7 +409,7 @@ class Relation(metaclass = MetaSet):
         return len(self.values)
 
     def __iter__(self) -> iter:
-        return iter(self.values)
+        return iter(MetaSet.Set(self.values))
 
     def __repr__(self):
         return f"{self.__class__.__name__} - {self.name} : " + f"{self.values}" if self.values else "Empty"

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -141,7 +141,7 @@ class MetaSet(type):
             elif isinstance(initvalue, MetaSet):
                 self._set = initvalue.objects()
             elif isinstance(initvalue, Signature):
-                self._set = initvalue.elements
+                self._set = set(initvalue.elements)
             elif isinstance(initvalue, Relation):
                 self._set = initvalue.values
             elif isinstance(initvalue, tuple):
@@ -149,20 +149,25 @@ class MetaSet(type):
             elif isinstance(initvalue, str):
                 self._set = {initvalue}
             elif isinstance(initvalue, dict):
-                self._set = {initvalue.values()}
+                self._set = set(initvalue.values())
             elif isinstance(initvalue, int):
                 self._set = {initvalue}
             else:
                 print("Exception, unsupported type in MetaSet::Set: %s", type(initvalue))
 
-        def __len__(self):
-            return len(self._set)
+        def __len__(cls):
+            return len(cls._set)
 
-        def __iter__(self):
-            return iter(self._set)
+        def __iter__(cls):
+            return iter(cls._set)
 
-        def __repr__(self):
-            return str(self._set)
+        def __repr__(cls):
+            return str(cls._set)
+
+        def __eq__(cls, other):
+            if not isinstance(other, MetaSet.Set):
+                return cls == MetaSet.Set(other)
+            return cls._set == other._set
 
         # override "in" operator, e.g.,: other in cls
         def __contains__(cls, other) -> bool:
@@ -186,11 +191,32 @@ class MetaSet(type):
         def __mul__(cls, other) -> set(tuple):
             return set(itertools.product(cls._set, other._set))
 
+        # override "^" operator as join
+        def __xor__(cls, other) -> set(tuple):
+            if not isinstance(other, MetaSet.Set):
+                return cls ^ MetaSet.Set(other)
+            ret = set()
+            for i in cls._set:
+                for j in other._set:
+                    if isinstance(i, str):
+                        i = tuple([i])
+                    if isinstance(j, str):
+                        j = tuple([j])
+                    if len(i) + len(j) > 2 and i[-1] == j[0]:
+                        if len(i[:-1] + j[1:]) == 1:
+                            ret.add((i[:-1] + j[1:])[0])
+                        else:
+                            ret.add(i[:-1] + j[1:])
+            return MetaSet.Set(ret)
+
     def __len__(cls):
         return len(cls.objects())
 
     def __iter__(cls):
         return iter(cls.objects())
+
+    def __repr__(cls) -> str:
+        return f"{cls.__name__}: " + f"{cls.objects()}" if cls.objects() else "Empty"
 
     # override "in" operator, e.g.,: other in cls
     def __contains__(cls, other):
@@ -208,11 +234,15 @@ class MetaSet(type):
     def __mul__(cls, other) -> set(tuple):
         return MetaSet.Set(cls.objects()) * MetaSet.Set(other)
 
+    # override "^" operator as join
+    def __xor__(cls, other) -> set(tuple):
+        return MetaSet.Set(cls.objects()) ^ MetaSet.Set(other)
+
     # all objects in this static variable
     def objects(cls) -> set:
-        if hasattr(cls, 'possible_tuples'):
-            return cls.possible_tuples()    # Relation
-        return cls.atoms                    # Signature
+        if hasattr(cls, 'values'): # Relation
+            return cls.values
+        return cls.atoms           # Signature
 
 
 class Multiplicity(Enum):
@@ -303,7 +333,10 @@ class Signature(metaclass = MetaSet):
         return iter(self.elements)
 
     def __repr__(self):
-        return f"{self.__class__.__name__} - {self.name} : {self.elements}" if self.elements else f"{self.__class__.__name__} - {self.name} : Empty"
+        return f"{self.__class__.__name__} - {self.name} : " + f"{self.elements}" if self.elements else "Empty"
+
+    def __eq__(self, other: object) -> bool:
+        return MetaSet.Set(other) == MetaSet.Set(self.elements)
 
     # override "in" operator, e.g.,: other in self
     def __contains__(self, other):
@@ -321,6 +354,9 @@ class Signature(metaclass = MetaSet):
     def __mul__(self, other) -> set(tuple):
         return MetaSet.Set(self.elements) * MetaSet.Set(other)
 
+    # override "^" operator as join
+    def __xor__(self, other) -> set(tuple):
+        return MetaSet.Set(self.elements) ^ MetaSet.Set(other)
 
 class Relation(metaclass = MetaSet):
     def __init__(self, name, types, values=set()):
@@ -337,12 +373,7 @@ class Relation(metaclass = MetaSet):
         self.types = types
         self.values = values
 
-    @classmethod
-    def possible_tuples(cls) -> set:
-        domain_elements = [type.objects() for type in cls.types]
-        return set([tup for tup in itertools.product(*domain_elements)])
-
-    def possible_tuples_instance_method(self) -> set:
+    def possible_tuples(self) -> set:
         domain_elements = [type.objects() for type in self.types]
         return set([tup for tup in itertools.product(*domain_elements)])
 
@@ -350,10 +381,10 @@ class Relation(metaclass = MetaSet):
         return self.values
 
     def generate_random_value(self):
-        return random_subset(self.possible_tuples_instance_method())
+        return random_subset(self.possible_tuples())
 
     def possible_next_values(self):
-        ret = list(powerset(self.possible_tuples_instance_method()))
+        ret = list(powerset(self.possible_tuples()))
         random.shuffle(ret)
         return ret
 
@@ -381,7 +412,7 @@ class Relation(metaclass = MetaSet):
         return iter(self.values)
 
     def __repr__(self):
-        return f"{self.__class__.__name__} - {self.name} : {self.values}" if self.values else f"{self.__class__.__name__} - {self.name} : Empty"
+        return f"{self.__class__.__name__} - {self.name} : " + f"{self.values}" if self.values else "Empty"
 
     # override "in" operator, e.g.,: other in self
     def __contains__(self, other):
@@ -395,6 +426,9 @@ class Relation(metaclass = MetaSet):
     def __sub__(self, other):
         return MetaSet.Set(self.values) - MetaSet.Set(other)
 
+    # override "^" operator as join
+    def __xor__(self, other) -> set(tuple):
+        return MetaSet.Set(self.values) ^ MetaSet.Set(other)
 
 #end
 class VariableTracker:
@@ -636,21 +670,17 @@ $padding        except MultiLevelExit:
 $padding            SS.${var} = ${var}_updated
                 #end
 $padding        else:
-$padding            # TODO backtrack to earlier steps
 $padding            print("No possible next state values")
 $padding            exit(1)
             #end
 $padding        print(Blue + "Taking transition ${trans.getTransName()}" + Reset)
 $padding        # Apply State Activeness Changes
                 #if($trans.getNonActiveStatesAfterTrans().size() > 0)
-$padding        # size = $trans.getNonActiveStatesAfterTrans().size()
 $padding        states_becoming_non_active = $trans.getNonActiveStatesAfterTransPythonStr()
 $padding        for state in states_becoming_non_active:
 $padding            state.is_active = False
                 #end
                 #if($trans.getActiveStatesAfterTrans().size() > 0)
-$padding        # TODO: delete this later. Do we need the line below?
-$padding        # size = $trans.geActiveStatesAfterTrans().size()
 $padding        states_becoming_active = $trans.getActiveStatesAfterTransPythonStr()
 $padding        for state in states_becoming_active:
 $padding            state.is_active = True
@@ -665,7 +695,6 @@ $padding        return True
         #end
     #end
 #end
-
 #foreach($rootState in $rootStates)
 	#generateState($rootState "")
 #end

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -89,8 +89,10 @@ public class DashPythonTranslationTest {
             assertTrue(decl.contains("="));
         }
 
-        assertTrue(gameState.getDecls().contains("Game_active_players = Player('active_players', 3)"));
-        assertTrue(gameState.getDecls().contains("Game_active_chairs = Chair('active_chairs', 3)"));
+        System.out.println(gameState.getDecls());
+
+        assertTrue(gameState.getDecls().contains("Game_active_players = Player('active_players', Multiplicity.Set)"));
+        assertTrue(gameState.getDecls().contains("Game_active_chairs = Chair('active_chairs', Multiplicity.Set)"));
         assertTrue(gameState.getDecls().contains("Game_occupied = Chair * Player"));
 
         for (String init : gameState.getInits()) {
@@ -397,18 +399,18 @@ public class DashPythonTranslationTest {
         assertEquals(12, transitions.size());
 
         List<String> expectedString = Arrays.asList(
-                "SS.StateA_far = SS.StateA_far",
-                "SS.StateA_far = SS.StateA_far",
-                "SS.StateA_far = SS.StateA_far",
-                "SS.StateA_far = SS.StateA_far + SigA",
-                "SS.StateA_far = SS.StateA_far + SigA + SigB",
-                "SS.StateA_far = SS.StateA_far + SigA + SigB",
-                "SS.StateA_far = SS.StateA_far + (SigB + SigA)",
-                "SS.StateA_far = SS.StateA_far - SigA",
-                "SS.StateA_far = SS.StateA_far - SigA - SigB",
-                "SS.StateA_far = SS.StateA_far - SigA - SigB",
-                "SS.StateA_far = SS.StateA_far - (SigA - SigB)",
-                "SS.StateA_far = SS.StateA_far + SigA - (SigB - SS.StateA_far)");
+                "SS.StateA_far == SS.StateA_far",
+                "SS.StateA_far == SS.StateA_far",
+                "SS.StateA_far == SS.StateA_far",
+                "SS.StateA_far == SS.StateA_far + SigA",
+                "SS.StateA_far == SS.StateA_far + SigA + SigB",
+                "SS.StateA_far == SS.StateA_far + SigA + SigB",
+                "SS.StateA_far == SS.StateA_far + (SigB + SigA)",
+                "SS.StateA_far == SS.StateA_far - SigA",
+                "SS.StateA_far == SS.StateA_far - SigA - SigB",
+                "SS.StateA_far == SS.StateA_far - SigA - SigB",
+                "SS.StateA_far == SS.StateA_far - (SigA - SigB)",
+                "SS.StateA_far == SS.StateA_far + SigA - (SigB - SS.StateA_far)");
 
         for (int index = 0; index < transitions.size(); index++) {
             assertEquals(expectedString.get(index), transitions.get(index).getActions().get(0));

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslationTest.java
@@ -400,17 +400,17 @@ public class DashPythonTranslationTest {
 
         List<String> expectedString = Arrays.asList(
                 "SS.StateA_far == SS.StateA_far",
-                "SS.StateA_far == SS.StateA_far",
-                "SS.StateA_far == SS.StateA_far",
-                "SS.StateA_far == SS.StateA_far + SigA",
-                "SS.StateA_far == SS.StateA_far + SigA + SigB",
-                "SS.StateA_far == SS.StateA_far + SigA + SigB",
-                "SS.StateA_far == SS.StateA_far + (SigB + SigA)",
-                "SS.StateA_far == SS.StateA_far - SigA",
-                "SS.StateA_far == SS.StateA_far - SigA - SigB",
-                "SS.StateA_far == SS.StateA_far - SigA - SigB",
-                "SS.StateA_far == SS.StateA_far - (SigA - SigB)",
-                "SS.StateA_far == SS.StateA_far + SigA - (SigB - SS.StateA_far)");
+                "StateA_far_updated == SS.StateA_far",
+                "StateA_far_updated == SS.StateA_far",
+                "StateA_far_updated == SS.StateA_far + SigA",
+                "StateA_far_updated == SS.StateA_far + SigA + SigB",
+                "StateA_far_updated == SS.StateA_far + SigA + SigB",
+                "StateA_far_updated == SS.StateA_far + (SigB + SigA)",
+                "StateA_far_updated == SS.StateA_far - SigA",
+                "StateA_far_updated == SS.StateA_far - SigA - SigB",
+                "StateA_far_updated == SS.StateA_far - SigA - SigB",
+                "StateA_far_updated == SS.StateA_far - (SigA - SigB)",
+                "StateA_far_updated == SS.StateA_far + SigA - (SigB - SS.StateA_far)");
 
         for (int index = 0; index < transitions.size(); index++) {
             assertEquals(expectedString.get(index), transitions.get(index).getActions().get(0));

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -250,8 +250,8 @@ public class CoreDashToPythonTest {
                 "SS.S_in_m1 == SS.S_in_m2 or",  // Equal sign in guard 1
                 "(SS.S_m1 == SS.S_m2 and",
                 "SS.S_in_m1 == SS.S_in_m2))",
-                "SS.S_in_m1 = SS.S_in_m2 + SS.S_in_m1",  // Equal sign in action 1
-                "SS.S_m1 = SS.S_m2 + SS.S_m1 + SS.S_m4"
+                "SS.S_in_m1 == SS.S_in_m2 + SS.S_in_m1",  // Equal sign in action 1
+                "SS.S_m1 == SS.S_m2 + SS.S_m1 + SS.S_m4"
         );
 
         String output = CoreDashToPython.convert2String(translation);

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -251,10 +251,12 @@ public class CoreDashToPythonTest {
                 "(SS.S_m1 == SS.S_m2 and",
                 "SS.S_in_m1 == SS.S_in_m2))",
                 "SS.S_in_m1 == SS.S_in_m2 + SS.S_in_m1",  // Equal sign in action 1
-                "SS.S_m1 == SS.S_m2 + SS.S_m1 + SS.S_m4"
+                "S_m1_updated == SS.S_m2 + SS.S_m1 + SS.S_m4"
         );
 
         String output = CoreDashToPython.convert2String(translation);
+
+        System.out.println(output);
 
         for(String trans : expectedTranslation){
             assert (output.contains(trans));

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -175,11 +175,10 @@ public class DashExprToPython<ExprType> {
                 String operation = type.equals("plus") ? " + " : " - ";
                 return UnaryOp2PythonOp(cardinality.op, cardinality.sub) + operation + badNode.left.toString();
             } else if (badNode.right instanceof ExprVar){
-                // This probably means it's a map (e.g., A.B => A[B])
-                // TODO: this is a hack and did not handle the case, only to prevent exceptions, need to fix
+                // Join operation (e.g., A.B => A ^ B)
                 String nodeLeft = genExpr(badNode.left, 1);
                 String nodeRight = genExpr(badNode.right, 1);
-                return nodeLeft + "." + nodeRight;
+                return nodeLeft + " ^ " + nodeRight;
             } else {
                 System.out.println("[Warning] BadNode needs more types: " + node.getClass());
             }
@@ -391,7 +390,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case JOIN:
-                res = " ";
+                res = this.genExpr(node.left, 1) + " ^ ";
                 break;
             case DOMAIN:
                 res = " ";

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -166,9 +166,7 @@ public class DashExprToPython<ExprType> {
                 return UnaryOp2PythonOp(cardinality.op, cardinality.sub) + operation + badNode.left.toString();
             } else if (badNode.right instanceof ExprVar){
                 // Join operation (e.g., A.B => A ^ B)
-                String nodeLeft = genExpr(badNode.left, 1);
-                String nodeRight = genExpr(badNode.right, 1);
-                return "(" + nodeLeft + " ^ " + nodeRight + ")";
+                return "(" + genExpr(badNode.left, 1) + " ^ " + genExpr(badNode.right, 1) + ")";
             } else {
                 System.out.println("[Warning] BadNode needs more types: " + node.getClass());
             }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -12,7 +12,7 @@ import java.util.*;
  */
 public class DashExprToPython<ExprType> {
     enum ExprTypeE {
-        DO, PRED, DEFAULT
+        DO, DEFAULT
     }
     private final String varTrackerName = "SS.";
     private ExprTypeE exprType;
@@ -68,15 +68,10 @@ public class DashExprToPython<ExprType> {
                 continue;
             }
             // Concatenate to the previous expression.
-            if(ExprTypeE.PRED == exprType){
-                // Format the predicate.
-                if (expr.charAt(0) == ')') {
-                    result.set(result.size() - 1, result.get(result.size() - 1).concat(trimmedExpr));
-                }else if(trimmedExpr.equals("or") || trimmedExpr.equals("and")){
-                    result.set(result.size() - 1, result.get(result.size() - 1).concat(" " + trimmedExpr));
-                }else{
-                    result.add(trimmedExpr);
-                }
+            if (expr.charAt(0) == ')') {
+                result.set(result.size() - 1, result.get(result.size() - 1).concat(trimmedExpr));
+            }else if(trimmedExpr.equals("or") || trimmedExpr.equals("and")){
+                result.set(result.size() - 1, result.get(result.size() - 1).concat(" " + trimmedExpr));
             }else{
                 result.add(trimmedExpr);
             }
@@ -124,27 +119,20 @@ public class DashExprToPython<ExprType> {
             }
 
             // predicates need to be wrapped in () and must be linked with and/or operators
-            if (ExprTypeE.PRED == exprType) {
-                sbs.getLast().append("(");
-                while (subNode.hasNext()) {
-                    sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
-                    // linkOperators
-                    if (subNode.hasNext()) {
-                        if (exprList.op == ExprList.Op.AND) {
-                            sbs.getLast().append(" and ");
-                        } else if (exprList.op == ExprList.Op.OR) {
-                            sbs.getLast().append(" or ");
-                        }
-                    } else {
-                        sbs.getLast().append(")");
+            sbs.getLast().append("(");
+            while (subNode.hasNext()) {
+                sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
+                // linkOperators
+                if (subNode.hasNext()) {
+                    if (exprList.op == ExprList.Op.AND) {
+                        sbs.getLast().append(" and ");
+                    } else if (exprList.op == ExprList.Op.OR) {
+                        sbs.getLast().append(" or ");
                     }
-                    sbs.addLast(new StringBuilder());
+                } else {
+                    sbs.getLast().append(")");
                 }
-            } else {
-                while (subNode.hasNext()) {
-                    sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
-                    sbs.addLast(new StringBuilder());
-                }
+                sbs.addLast(new StringBuilder());
             }
 
             return "";
@@ -160,9 +148,11 @@ public class DashExprToPython<ExprType> {
             return BinaryOp2PythonOp((ExprBinary) node);
         } else if (node instanceof ExprVar || node instanceof ExprConstant){
             String varName = node.toString();
-            if('\'' == varName.charAt(varName.length() - 1)){   // primed variable
-                varName = varName.substring(0, varName.length() - 1);
-                assignableVars.add(getVarName(varName).substring(varTrackerName.length()));
+            // Prime variables will have a suffix "_updated"
+            if(ExprTypeE.DO == exprType && '\'' == varName.charAt(varName.length() - 1)){
+                varName = getVarName(varName.substring(0, varName.length() - 1)).substring(varTrackerName.length());
+                assignableVars.add(varName);
+                return varName + "_updated";
             }
 			return getVarName(varName);
         } else if (node instanceof ExprBadJoin) {
@@ -178,7 +168,7 @@ public class DashExprToPython<ExprType> {
                 // Join operation (e.g., A.B => A ^ B)
                 String nodeLeft = genExpr(badNode.left, 1);
                 String nodeRight = genExpr(badNode.right, 1);
-                return nodeLeft + " ^ " + nodeRight;
+                return "(" + nodeLeft + " ^ " + nodeRight + ")";
             } else {
                 System.out.println("[Warning] BadNode needs more types: " + node.getClass());
             }
@@ -321,7 +311,7 @@ public class DashExprToPython<ExprType> {
     // translate Binary operation, also returns the empty space
     private String BinaryOp2PythonOp(ExprBinary node){
         String res = " ";
-        boolean shouldDddParenthesis = node.right instanceof ExprBinary;
+        boolean shouldAddParenthesis = node.right instanceof ExprBinary;
         boolean rightConsumed = false;  // if the right expression is already parsed
         switch(node.op){
             case ARROW:     // State relation declaration
@@ -391,6 +381,7 @@ public class DashExprToPython<ExprType> {
                 break;
             case JOIN:
                 res = this.genExpr(node.left, 1) + " ^ ";
+                shouldAddParenthesis = true;
                 break;
             case DOMAIN:
                 res = " ";
@@ -428,13 +419,10 @@ public class DashExprToPython<ExprType> {
             case EQUALS:        // this part assumes inner expression is a signature instances and are comparable
             	if(isInit) {    // TODO: this should be deprecated if we assume the Alloy Solver can always handle the initialization
             		res = this.genExpr(node.left, 1) + " = " + this.genExpr(node.right, 1).toLowerCase();
-            	} else if (ExprTypeE.DO == exprType){
-                    // TODO: delete this part if we assume the Alloy Solver can always handle the initialization
-            		res = varTrackerName + this.genExpr(node.left, 1).substring(varTrackerName.length()) + " = ";
             	} else {        // predicates
                     res = this.genExpr(node.left, 1) + " == ";
                 }
-                shouldDddParenthesis = false;
+                shouldAddParenthesis = false;
                 break;
             case NOT_EQUALS:    // this part assumes inner expression is a signature instances and are comparable
                 res = this.genExpr(node.left, 1) + " != ";
@@ -498,7 +486,7 @@ public class DashExprToPython<ExprType> {
 
         // add the right expression node
         if (!rightConsumed){
-            if(shouldDddParenthesis) {
+            if(shouldAddParenthesis) {
                 res += "(" + this.genExpr(node.right, 1) + ")";
             }else{
                 res += this.genExpr(node.right, 1);

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -1097,11 +1097,11 @@ public class DashPythonTranslation {
                 this.eventCondition = dashTrans.getTriggerEvent().getRawName();
             }
             if(dashTrans.getCondition() != null){       // determines the guard_condition (if statement)
-                DashExprToPython<DashWhenExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED);
+                DashExprToPython<DashWhenExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getCondition(), variable2StateNameMap);
                 this.guardConditions = dashExprTranslator.toList();
             }
             if(dashTrans.getAction() != null){  // determines the action
-                DashExprToPython<DashDoExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap,DashExprToPython.ExprTypeE.PRED);
+                DashExprToPython<DashDoExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap,DashExprToPython.ExprTypeE.DO);
 
                 this.actions = dashExprTranslator.toList();
                 this.assignableVars = dashExprTranslator.getAssignableVars();
@@ -1165,7 +1165,7 @@ public class DashPythonTranslation {
 
             // determines the invariant condition
             if(dashInvariant.getExpr() != null){
-                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.PRED);
+                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.DEFAULT);
                 this.conditions = dashExprTranslator.toList();
                 this.relatedVariables = dashExprTranslator.getRelatedDynamicVars();
             }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -1165,7 +1165,7 @@ public class DashPythonTranslation {
 
             // determines the invariant condition
             if(dashInvariant.getExpr() != null){
-                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.DEFAULT);
+                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap);
                 this.conditions = dashExprTranslator.toList();
                 this.relatedVariables = dashExprTranslator.getRelatedDynamicVars();
             }


### PR DESCRIPTION
Changes:
- Made PRED mode the DEFAULT in expression translation. Basically, now we removed the assumption of "simple assignments" in actions, and all expressions are seen as predicates (the default mode).
- Supported both the translation and execution of operators `==`, `!=`, `^` (join), and `for x in y`

Not done:
- Invariant is not integrated with this method yet. But `farmer.dsh` doesn't have invariants.

Farmer.dsh is executable now.
```
abstract sig Object {
    eats: set Object
}
one sig Chicken, Farmer, Fox, Grain extends Object {}

fact eating {
    eats = Fox -> Chicken + Chicken -> Grain
}

conc state Puzzle {
    near: set Object
    far: set Object

    init {
        near = Object
        no far
    }

    trans near2far {
        when Farmer in near
        do {
            // Farmer takes one Object
            (one x: near - Farmer | {
                near' = near - Farmer - x - near'.eats
                far' = far + Farmer + x
            }) or
            // Farmer crosses alone
            {
                near' = near - Farmer - near'.eats
                far' = far + Farmer
            }
        }
    }

    trans far2near {
        when Farmer in far
        do {
            // Farmer takes one Object
            (one x: far - Farmer | {
                far' = far - Farmer - x - far'.eats
                near' = near + Farmer + x
            }) or
            // Farmer crosses alone
            {
                far' = far - Farmer - far'.eats
                near' = near + Farmer
            }
        }
    }
}
```
Translation:
```
class Puzzle_State(State):

    def __init__(self, parent_state: State, root_state: State) -> None:
        global ref_puzzle
        ref_puzzle = self # Initialize global reference to this state
        super(Puzzle_State, self).__init__(None, self) # init superclass
        self.is_conc = True
        # No substate for this state, so default state is None

        # state variable declarations
        SS.Puzzle_near = Object('near', Multiplicity.Set, {"Chicken$0", "Farmer$0", "Fox$0", "Grain$0"})
        SS.Puzzle_far = Object('far', Multiplicity.Set, set())

        # initialize state transition dictionary
        self.transitions[self._trans_near2far_guard] = self._trans_near2far
        self.transitions[self._trans_far2near_guard] = self._trans_far2near

    # transitions
    # guard for near2far
    def _trans_near2far_guard(self) -> bool:
        if not (Farmer in SS.Puzzle_near):
            return False
        return True

    # execution for near2far
    def _trans_near2far(self) -> bool:
        try:
            for Puzzle_near_updated in SS.Puzzle_near.possible_next_values():
                Puzzle_near_updated = MetaSet.Set(set(Puzzle_near_updated))
                for Puzzle_far_updated in SS.Puzzle_far.possible_next_values():
                    Puzzle_far_updated = MetaSet.Set(set(Puzzle_far_updated))
                    if ((1 == [(Puzzle_near_updated == SS.Puzzle_near - Farmer - x - (Puzzle_near_updated ^ eats) and Puzzle_far_updated == SS.Puzzle_far + Farmer + x) for x in SS.Puzzle_near - Farmer].count(True)) or
                        (Puzzle_near_updated == SS.Puzzle_near - Farmer - (Puzzle_near_updated ^ eats) and
                        Puzzle_far_updated == SS.Puzzle_far + Farmer)):
                            raise MultiLevelExit
        except MultiLevelExit:
            SS.Puzzle_near = Puzzle_near_updated
            SS.Puzzle_far = Puzzle_far_updated
        else:
            print("No possible next state values")
            exit(1)
        print(Blue + "Taking transition near2far" + Reset)
        # Apply State Activeness Changes
        states_becoming_active = [ref_puzzle]
        for state in states_becoming_active:
            state.is_active = True
        return True

    # guard for far2near
    def _trans_far2near_guard(self) -> bool:
        if not (Farmer in SS.Puzzle_far):
            return False
        return True

    # execution for far2near
    def _trans_far2near(self) -> bool:
        try:
            for Puzzle_near_updated in SS.Puzzle_near.possible_next_values():
                Puzzle_near_updated = MetaSet.Set(set(Puzzle_near_updated))
                for Puzzle_far_updated in SS.Puzzle_far.possible_next_values():
                    Puzzle_far_updated = MetaSet.Set(set(Puzzle_far_updated))
                    if ((1 == [(Puzzle_far_updated == SS.Puzzle_far - Farmer - x - (Puzzle_far_updated ^ eats) and Puzzle_near_updated == SS.Puzzle_near + Farmer + x) for x in SS.Puzzle_far - Farmer].count(True)) or
                        (Puzzle_far_updated == SS.Puzzle_far - Farmer - (Puzzle_far_updated ^ eats) and
                        Puzzle_near_updated == SS.Puzzle_near + Farmer)):
                            raise MultiLevelExit
        except MultiLevelExit:
            SS.Puzzle_near = Puzzle_near_updated
            SS.Puzzle_far = Puzzle_far_updated
        else:
            print("No possible next state values")
            exit(1)
        print(Blue + "Taking transition far2near" + Reset)
        # Apply State Activeness Changes
        states_becoming_active = [ref_puzzle]
        for state in states_becoming_active:
            state.is_active = True
        return True
```