### PR TITLE
Support invariants with the runtime solver

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -326,6 +326,9 @@ class Signature(metaclass = MetaSet):
         random.shuffle(ret)
         return ret
 
+    # Alias for possible_next_values
+    pnv = possible_next_values
+
     def __len__(self) -> int:
         return len(self.elements)
 
@@ -384,9 +387,12 @@ class Relation(metaclass = MetaSet):
         return random_subset(self.possible_tuples())
 
     def possible_next_values(self):
-        ret = list(powerset(self.possible_tuples_instance_method()))
+        ret = list(powerset(self.possible_tuples()))
         random.shuffle(ret)
         return ret
+
+    # Alias for possible_next_values
+    pnv = possible_next_values
 
     # Returns true if the new set of tuples is valid for its types
     def is_valid(self, values) -> bool:
@@ -651,7 +657,7 @@ $padding            return False
 $padding        try:
                 #foreach($var in $trans.getAssignedVarNames())
                     #set($padding = "$padding$tab")
-$padding        for ${var}_updated in SS.${var}.possible_next_values():
+$padding        for ${var}_updated in SS.${var}.pnv():
 $padding            ${var}_updated = MetaSet.Set(set(${var}_updated))
                 #end
                 #if(!$trans.getInvariantNames().isEmpty())

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -158,8 +158,10 @@ class MetaSet(type):
         def __len__(cls):
             return len(cls._set)
 
-        def __iter__(cls):
-            return iter(cls._set)
+        def __iter__(cls) -> iter:
+            _list = list(cls._set)
+            random.shuffle(_list)
+            return iter([MetaSet.Set(e) for e in _list])
 
         def __repr__(cls):
             return str(cls._set)
@@ -212,7 +214,7 @@ class MetaSet(type):
     def __len__(cls):
         return len(cls.objects())
 
-    def __iter__(cls):
+    def __iter__(cls) -> iter:
         return iter(MetaSet.Set(cls.objects()))
 
     def __repr__(cls) -> str:
@@ -326,9 +328,6 @@ class Signature(metaclass = MetaSet):
         random.shuffle(ret)
         return ret
 
-    # Alias for possible_next_values
-    pnv = possible_next_values
-
     def __len__(self) -> int:
         return len(self.elements)
 
@@ -390,9 +389,6 @@ class Relation(metaclass = MetaSet):
         ret = list(powerset(self.possible_tuples()))
         random.shuffle(ret)
         return ret
-
-    # Alias for possible_next_values
-    pnv = possible_next_values
 
     # Returns true if the new set of tuples is valid for its types
     def is_valid(self, values) -> bool:
@@ -657,7 +653,7 @@ $padding            return False
 $padding        try:
                 #foreach($var in $trans.getAssignedVarNames())
                     #set($padding = "$padding$tab")
-$padding        for ${var}_updated in SS.${var}.pnv():
+$padding        for ${var}_updated in SS.${var}.possible_next_values():
 $padding            ${var}_updated = MetaSet.Set(set(${var}_updated))
                 #end
                 #if(!$trans.getInvariantNames().isEmpty())

--- a/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
+++ b/org.alloytools.alloy.application/src/main/java/templates/TestTemplateFile.vm
@@ -502,7 +502,7 @@ class ${relation.Name}(Relation):
 #if($invariants)
 # --- Invariants ---
     #foreach($inv in $invariants)
-def ${inv.getName()}() -> bool:
+def ${inv.getInvariantName()} -> bool:
     #if($inv.getConditions().size() == 1)
     return ($inv.getConditions().get(0))
     #else
@@ -628,18 +628,18 @@ $padding        ${var}_tmp = SS.${var}
 $padding        ${action}
                 #end
                 #if($trans.getInvariantNames().size() == 1)
-$padding        if not $trans.getInvariantNames().get(0)():
+$padding        if not $trans.getInvariantNames().get(0):
                     #foreach($var in $trans.getAssignedVarNames())
 $padding            SS.${var} = ${var}_tmp
                     #end
 $padding            return False
                 #elseif($trans.getInvariantNames().size() > 1)
-$padding        if not ($trans.getInvariantNames().get(0)() and
+$padding        if not ($trans.getInvariantNames().get(0) and
                     #set($lastIndex = ${trans.getInvariantNames().size()} - 1)
                     #foreach($invariantName in ${trans.getInvariantNames().subList(1, $lastIndex)})
-$padding            ${invariantName}() and
+$padding            ${invariantName} and
                     #end
-$padding            ${trans.getInvariantNames().get($lastIndex)}()):
+$padding            ${trans.getInvariantNames().get($lastIndex)}):
                     #foreach($var in $trans.getAssignedVarNames())
 $padding            SS.${var} = ${var}_tmp
                     #end
@@ -654,17 +654,32 @@ $padding        try:
 $padding        for ${var}_updated in SS.${var}.possible_next_values():
 $padding            ${var}_updated = MetaSet.Set(set(${var}_updated))
                 #end
-                #if($trans.getActions().size() == 1)
-$padding            if $trans.getActions().get(0):
-                #elseif($trans.getActions().size() > 1)
-$padding            if $trans.getActions().get(0)
-                    #set($lastIndex = ${trans.getActions().size()} - 1)
-                    #foreach($action in ${trans.getActions().subList(1, $lastIndex)})
-$padding                ${action}
+                #if(!$trans.getInvariantNames().isEmpty())
+                    #if($trans.getInvariantNames().size() == 1)
+$padding            if not $trans.getInvariantNames().get(0):
+                    #elseif($trans.getInvariantNames().size() > 1)
+$padding            if not ($trans.getInvariantNames().get(0) and
+                        #set($lastIndex = ${trans.getInvariantNames().size()} - 1)
+                        #foreach($invariantName in ${trans.getInvariantNames().subList(1, $lastIndex)})
+$padding                ${invariantName} and
+                        #end
+$padding                ${trans.getInvariantNames().get($lastIndex)}):
                     #end
-$padding                ${trans.getActions().get($lastIndex)}:
+$padding                continue
                 #end
-$padding                    raise MultiLevelExit
+                #if(!$trans.getActions().isEmpty())
+                    #if($trans.getActions().size() == 1)
+$padding            if $trans.getActions().get(0):
+                    #elseif($trans.getActions().size() > 1)
+$padding            if $trans.getActions().get(0)
+                        #set($lastIndex = ${trans.getActions().size()} - 1)
+                        #foreach($action in ${trans.getActions().subList(1, $lastIndex)})
+$padding                ${action}
+                        #end
+$padding                ${trans.getActions().get($lastIndex)}:
+                    #end
+                #end
+$padding                raise MultiLevelExit
                 #set($padding = "$oldpadding")
 $padding        except MultiLevelExit:
                 #foreach($var in $trans.getAssignedVarNames())

--- a/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
+++ b/org.alloytools.alloy.application/src/test/java/ca/uwaterloo/watform/transform/CoreDashToPythonTest.java
@@ -256,15 +256,13 @@ public class CoreDashToPythonTest {
 
         String output = CoreDashToPython.convert2String(translation);
 
-        System.out.println(output);
-
         for(String trans : expectedTranslation){
             assert (output.contains(trans));
         }
     }
 
     @Test
-    public void test_QuantifiedExpressions_Correct() throws IOException {
+    public void test_QuantifiedExpressions_InInvariants_Correct() throws IOException {
         String dashModel = "sig Patient {} sig Medication {} conc state EHealthSystem { medications: set Medication " +
                 "patients: set Patient prescriptions: Patient -> set Medication interactions: Medication -> set Medication " +
                 "invariant I_2_Types_1 { all m1, m2: medications, p: patients | m1 -> m2 in interactions and p in Patient}" +
@@ -280,13 +278,19 @@ public class CoreDashToPythonTest {
         DashPythonTranslation translation = new DashPythonTranslation(dashModule, null);
 
         List<String> expectedTranslation = Arrays.asList(
-            "(all([(m1 * m2 in SS.EHealthSystem_interactions and p in Patient) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))",
-            "(all([m1 * m2 in SS.EHealthSystem_interactions for m1 in Medication for m2 in Medication]))",
-            "(all([(m1 * m2 in SS.EHealthSystem_interactions and m2 * m3 in SS.EHealthSystem_interactions) for m1 in Medication for m2 in Medication for m3 in Medication]))",
-            "(all([(m1 * m2 in SS.EHealthSystem_interactions) == (m2 * m1 in SS.EHealthSystem_interactions) for m1 in Medication for m2 in Medication]))",
-            "(all([not(m * m in SS.EHealthSystem_interactions) for m in SS.EHealthSystem_medications]))",
-            "(all([(p * m1 in SS.EHealthSystem_prescriptions and p * m2 in SS.EHealthSystem_prescriptions) for m1 in SS.EHealthSystem_medications for m2 in SS.EHealthSystem_medications for p in SS.EHealthSystem_patients]))"
-            );
+            "def Inv_I_2_Types_1(medications, patients, interactions) -> bool:",
+            "return (all([(m1 * m2 in interactions and p in Patient) for m1 in medications for m2 in medications for p in patients]))",
+            "def Inv_I_2_Same_Type(interactions) -> bool:",
+            "return (all([m1 * m2 in interactions for m1 in Medication for m2 in Medication]))",
+            "def Inv_I_3_Same_type(interactions) -> bool:",
+            "return (all([(m1 * m2 in interactions and m2 * m3 in interactions) for m1 in Medication for m2 in Medication for m3 in Medication]))",
+            "def Inv_I_symmetry(interactions) -> bool:",
+            "return (all([(m1 * m2 in interactions) == (m2 * m1 in interactions) for m1 in Medication for m2 in Medication]))",
+            "def Inv_I_no_statement(medications, interactions) -> bool:",
+            "return (all([not(m * m in interactions) for m in medications]))",
+            "def Inv_I_2_Types_2(medications, patients, prescriptions) -> bool:",
+            "return (all([(p * m1 in prescriptions and p * m2 in prescriptions) for m1 in medications for m2 in medications for p in patients]))"
+        );
 
         String output = CoreDashToPython.convert2String(translation);
 
@@ -326,9 +330,7 @@ public class CoreDashToPythonTest {
                 "(1 == len(SS.EHealthSystem_patients))"
         );
 
-
         String output = CoreDashToPython.convert2String(translation);
-        System.out.println(output);
 
         for(String trans : expectedTranslation){
             assert (output.contains(trans));

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashExprToPython.java
@@ -5,16 +5,18 @@ import ca.uwaterloo.watform.ast.DashWhenExpr;
 import edu.mit.csail.sdg.ast.*;
 
 import java.util.*;
-
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /*
     a class used to translate expressions to Python code
  */
 public class DashExprToPython<ExprType> {
     enum ExprTypeE {
-        DO, DEFAULT
+        INV, DO, DEFAULT
     }
-    private final String varTrackerName = "SS.";
+    public static final String VarTrackerName = "SS.";
+    public static final String VarLocalSuffix = "_updated";
     private ExprTypeE exprType;
     private ExprType specialExpr;
     private Deque<StringBuilder> sbs;
@@ -25,8 +27,9 @@ public class DashExprToPython<ExprType> {
     public boolean isInit = false;
     // used to store the dynamic variables that are related to the current expression
     // only used for invariants
-    private Set<String> relatedDynamicVars;
-    private Set<String> assignableVars;
+
+    private final VariableSet relatedDynamicVars;      // All related variables, including the ones that are not assignable
+    private final VariableSet assignableVars;          // All assignable variables
 
     public DashExprToPython(ExprType specialExpr, Map<String, String> variable2StateNameMap, String varName, List<DashPythonTranslation.Relation> relations, ExprTypeE exprType){
         this.specialExpr = specialExpr;
@@ -36,8 +39,8 @@ public class DashExprToPython<ExprType> {
         this.varName = varName;
         this.relations = relations;
         this.exprType = exprType;
-        this.relatedDynamicVars = new HashSet<>();
-        this.assignableVars = new HashSet<>();
+        this.relatedDynamicVars = new VariableSet();
+        this.assignableVars = new VariableSet();
 
         // TODO: currently only support DashWhenExpr
         this.parseExpr();
@@ -79,8 +82,8 @@ public class DashExprToPython<ExprType> {
         return result;
     }
 
-    public Set<String> getRelatedDynamicVars() {return relatedDynamicVars;}
-    public List<String> getAssignableVars() {return new ArrayList<>(assignableVars);}
+    public VariableSet getRelatedDynamicVars() {return relatedDynamicVars;}
+    public VariableSet getAssignableVars() {return assignableVars;}
 
     public void reparseExpr() {
         sbs.removeLast();
@@ -93,17 +96,17 @@ public class DashExprToPython<ExprType> {
         // TODO: need to handle predicates with multiple lines
         if(specialExpr instanceof DashWhenExpr){
             DashWhenExpr exp = (DashWhenExpr)this.specialExpr;
-            sbs.getLast().append(genExpr(exp.getExpr(), exp.getAllExpressions().size()));
+            sbs.getLast().append(genExpr(exp.getExpr()));
         } else if (specialExpr instanceof DashDoExpr){
             DashDoExpr exp = (DashDoExpr)this.specialExpr;
-            sbs.getLast().append(genExpr(exp.getExpr(), exp.getAllExpression().size()));
+            sbs.getLast().append(genExpr(exp.getExpr()));
         } else {
-            sbs.getLast().append(genExpr((Expr)specialExpr, 1));
+            sbs.getLast().append(genExpr((Expr)specialExpr));
         }
     }
 
     // print the expr tree using pre-order
-    private String genExpr(Expr node, int size) {
+    private String genExpr(Expr node) {
         // TODO: currently, the second parameter is redundant
 
         // check type, there are two types of expr
@@ -113,7 +116,7 @@ public class DashExprToPython<ExprType> {
             Iterator<Expr> subNode = exprList.args.iterator();
 
             if (1 == exprList.args.size()){
-                sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
+                sbs.getLast().append(genExpr(subNode.next()));
                 sbs.addLast(new StringBuilder());
                 return "";
             }
@@ -121,7 +124,7 @@ public class DashExprToPython<ExprType> {
             // predicates need to be wrapped in () and must be linked with and/or operators
             sbs.getLast().append("(");
             while (subNode.hasNext()) {
-                sbs.getLast().append(genExpr(subNode.next(), exprList.args.size()));
+                sbs.getLast().append(genExpr(subNode.next()));
                 // linkOperators
                 if (subNode.hasNext()) {
                     if (exprList.op == ExprList.Op.AND) {
@@ -142,19 +145,26 @@ public class DashExprToPython<ExprType> {
             ExprUnary unaryNode = (ExprUnary) node;
             return UnaryOp2PythonOp(unaryNode.op, unaryNode.sub);
         } else if (node instanceof ExprBinary) {
-            // TODO: will BinaryExpr have sub nodes?
-
-            // TODO: will need to replace left and right with signature names
             return BinaryOp2PythonOp((ExprBinary) node);
         } else if (node instanceof ExprVar || node instanceof ExprConstant){
             String varName = node.toString();
-            // Prime variables will have a suffix "_updated"
-            if(ExprTypeE.DO == exprType && '\'' == varName.charAt(varName.length() - 1)){
-                varName = getVarName(varName.substring(0, varName.length() - 1)).substring(varTrackerName.length());
-                assignableVars.add(varName);
-                return varName + "_updated";
+            Variable var;
+            switch(exprType){
+                case INV:   // Invariant variables will be parameterized, so no change to the names
+                    var = getVarName(varName);
+                    return var.getName();
+                case DO:    // Prime variables will have a suffix in the actions
+                    if('\'' == varName.charAt(varName.length() - 1)){
+                        var = getVarName(varName.substring(0, varName.length() - 1));
+                        var.setHasSuffix(true);
+                        assignableVars.add(var);
+                        return var.getLocalName();
+                    }
+                    break;
+                default:
+                    break;
             }
-			return getVarName(varName);
+			return getVarName(varName).getQualName();
         } else if (node instanceof ExprBadJoin) {
             // this assumes the expr is in the form (#STATE_VARIABLE).PLUS/MINUS[CONSTANT]
             ExprBadJoin badNode = (ExprBadJoin) node;
@@ -166,7 +176,7 @@ public class DashExprToPython<ExprType> {
                 return UnaryOp2PythonOp(cardinality.op, cardinality.sub) + operation + badNode.left.toString();
             } else if (badNode.right instanceof ExprVar){
                 // Join operation (e.g., A.B => A ^ B)
-                return "(" + genExpr(badNode.left, 1) + " ^ " + genExpr(badNode.right, 1) + ")";
+                return "(" + genExpr(badNode.left) + " ^ " + genExpr(badNode.right) + ")";
             } else {
                 System.out.println("[Warning] BadNode needs more types: " + node.getClass());
             }
@@ -179,21 +189,21 @@ public class DashExprToPython<ExprType> {
 
             for(Decl decl : qtNode.decls){
                 // Get type/declaration of the quantified variables
-                String quantifiedDecl = genExpr(decl.expr, 1);
+                String quantifiedDecl = genExpr(decl.expr);
 
                 // Get the quantified variables
                 for (ExprHasName variable : decl.names) {
                     if (quantifiedSource.length() > 0){
                         quantifiedSource.append(" ");
                     }
-                    quantifiedSource.append(String.format("for %s in %s", genExpr(variable, 1), quantifiedDecl));
+                    quantifiedSource.append(String.format("for %s in %s", genExpr(variable), quantifiedDecl));
                 }
             }
             // Get the formula of the quantified expression
             Deque<StringBuilder> sbsTemp = sbs;
             this.sbs = new LinkedList<>();
             this.sbs.addLast(new StringBuilder());
-            String quantifiedFormula = genExpr(qtNode.sub, 1);
+            String quantifiedFormula = genExpr(qtNode.sub);
             // Meaning there are several statements in the quantified formula
             if(!sbs.getFirst().toString().isEmpty()){
                 quantifiedFormula = String.join(" ", toList());
@@ -245,7 +255,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case NOT:        // this part assumes the inner expression is a statement that evaluates to true or false
-                res = "not(" + this.genExpr(node,1) + ")";
+                res = "not(" + this.genExpr(node) + ")";
                 break;
             case AFTER:
                 res = " ";
@@ -266,16 +276,16 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case NO:        // this part assumes the inner expression is a signature instance that is an object
-                res = "not any(" + this.genExpr(node,1) + ")";
+                res = "not any(" + this.genExpr(node) + ")";
                 break;
             case SOME:      // this part assumes the inner expression is a signature instance that is an object
-                res = "any(" + this.genExpr(node,1) + ")";
+                res = "any(" + this.genExpr(node) + ")";
                 break;
             case LONE:
-                res = "(1 >= len(" + this.genExpr(node,1) + "))";
+                res = "(1 >= len(" + this.genExpr(node) + "))";
                 break;
             case ONE:
-                res = "(1 == len(" + this.genExpr(node,1) + "))";
+                res = "(1 == len(" + this.genExpr(node) + "))";
                 break;
             case TRANSPOSE:
                 res = " ";
@@ -291,7 +301,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case CARDINALITY:
-                res = "len(" + this.genExpr(node,1) + ")";
+                res = "len(" + this.genExpr(node) + ")";
                 break;
             case CAST2INT:
                 res = " ";
@@ -300,7 +310,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case NOOP:
-                res = this.genExpr(node, 1);
+                res = this.genExpr(node);
                 break;
         }
         return res;
@@ -312,22 +322,8 @@ public class DashExprToPython<ExprType> {
         boolean shouldAddParenthesis = node.right instanceof ExprBinary;
         boolean rightConsumed = false;  // if the right expression is already parsed
         switch(node.op){
-            case ARROW:     // State relation declaration
-                // TODO: should apply this to other relation types.
-            	// TODO: currently only support relation for exactly 2 types
-
-                // Generate new relation name and add it to the list of relations.
-                res = getVarName(node.left.toString()) + " * " + getVarName(node.right.toString());
-
-                // TODO: we assume the model can always be solved by Alloy Solver
-                /* [Deprecated]: now the Alloy Solver will handle the initialization of relations
-                    String type = "[" + node.left + ", " + node.right  + "]";
-                    DashPythonTranslation.Relation newRelation = new DashPythonTranslation.Relation(newRelationName, type);
-                    if (relations != null && !relations.contains(newRelation)){ relations.add(newRelation); }
-                    res = newRelationName + "()";
-                 */
-
-                rightConsumed = true;
+            case ARROW: // Cartesian product
+                res = this.genExpr(node.left) + " * ";
                 break;
             case ANY_ARROW_SOME:
                 res = " ";
@@ -378,7 +374,7 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case JOIN:
-                res = this.genExpr(node.left, 1) + " ^ ";
+                res = this.genExpr(node.left) + " ^ ";
                 shouldAddParenthesis = true;
                 break;
             case DOMAIN:
@@ -394,13 +390,13 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case PLUS:        // this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " + ";
+                res = this.genExpr(node.left) + " + ";
                 break;
             case IPLUS:
                 res = " ";
                 break;
             case MINUS:        // this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " - ";
+                res = this.genExpr(node.left) + " - ";
                 break;
             case IMINUS:
                 res = " ";
@@ -416,33 +412,33 @@ public class DashExprToPython<ExprType> {
                 break;
             case EQUALS:        // this part assumes inner expression is a signature instances and are comparable
             	if(isInit) {    // TODO: this should be deprecated if we assume the Alloy Solver can always handle the initialization
-            		res = this.genExpr(node.left, 1) + " = " + this.genExpr(node.right, 1).toLowerCase();
+            		res = this.genExpr(node.left) + " = " + this.genExpr(node.right).toLowerCase();
             	} else {        // predicates
-                    res = this.genExpr(node.left, 1) + " == ";
+                    res = this.genExpr(node.left) + " == ";
                 }
                 shouldAddParenthesis = false;
                 break;
             case NOT_EQUALS:    // this part assumes inner expression is a signature instances and are comparable
-                res = this.genExpr(node.left, 1) + " != ";
+                res = this.genExpr(node.left) + " != ";
                 break;
             case IMPLIES:
                 res = " ";
                 break;
             case LT:         // this part assumes inner expression are a signature instances and are comparable
             case NOT_GTE:
-                res = this.genExpr(node.left, 1) + " < ";
+                res = this.genExpr(node.left) + " < ";
                 break;
             case LTE:        // this part assumes inner expression are a signature instances and are comparable
             case NOT_GT:
-                res = this.genExpr(node.left, 1) + " <= ";
+                res = this.genExpr(node.left) + " <= ";
                 break;
             case GT:         // this part assumes inner expression are a signature instances and are comparable
             case NOT_LTE:
-                res = this.genExpr(node.left, 1) + " > ";
+                res = this.genExpr(node.left) + " > ";
                 break;
             case GTE:        // this part assumes inner expression are a signature instances and are comparable
             case NOT_LT:
-                res = this.genExpr(node.left, 1) + " >= ";
+                res = this.genExpr(node.left) + " >= ";
                 break;
             case SHL:
                 res = " ";
@@ -454,19 +450,19 @@ public class DashExprToPython<ExprType> {
                 res = " ";
                 break;
             case IN:            // this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " in ";
+                res = this.genExpr(node.left) + " in ";
                 break;
             case NOT_IN:        // this part assumes inner expression are a signature instances and are sets
-                res = this.genExpr(node.left, 1) + " not in ";
+                res = this.genExpr(node.left) + " not in ";
                 break;
             case AND:           // this part assumes the inner expression is a statement that evaluates to true or false
-                res = "(" + this.genExpr(node.left, 1) + ") and ";
+                res = "(" + this.genExpr(node.left) + ") and ";
                 break;
             case OR:            // this part assumes the inner expression is a statement that evaluates to true or false
-                res = "(" + this.genExpr(node.left, 1) + ") or ";
+                res = "(" + this.genExpr(node.left) + ") or ";
                 break;
             case IFF:
-                res = "(" + this.genExpr(node.left, 1) + ") == ";
+                res = "(" + this.genExpr(node.left) + ") == ";
                 break;
             case UNTIL:
                 res = " ";
@@ -485,24 +481,76 @@ public class DashExprToPython<ExprType> {
         // add the right expression node
         if (!rightConsumed){
             if(shouldAddParenthesis) {
-                res += "(" + this.genExpr(node.right, 1) + ")";
+                res += "(" + this.genExpr(node.right) + ")";
             }else{
-                res += this.genExpr(node.right, 1);
+                res += this.genExpr(node.right);
             }
         }
         return res;
     }
 
-    private String getVarName(String varName){
+    private Variable getVarName(String varName) {
+        Variable var = new Variable(varName);
         if (varName.contains("/")){
             String[] parts = varName.split("/");
-            relatedDynamicVars.add(parts[parts.length - 1]);
-            return varTrackerName + varName.replace("/", "_");
+            var.setGlobal(true);
+            var.setName(parts[parts.length - 1]);
+            varName = varName.replace("/", "_");
+            var.setPrefix(varName.substring(0, varName.lastIndexOf("_") + 1));
+            relatedDynamicVars.add(var);
+        } else if (variable2StateNameMap.containsKey(varName)){
+            var.setGlobal(true);
+            var.setPrefix(variable2StateNameMap.get(varName) + "_");
+            relatedDynamicVars.add(var);
         }
-        if (variable2StateNameMap.containsKey(varName)){
-            relatedDynamicVars.add(varName);
-            return varTrackerName + variable2StateNameMap.get(varName) + "_" + varName;
+        return var;
+    }
+
+    // "SS." + "<State Name>" + "<Name>" + "_updated"
+    public static class Variable{
+        private boolean isGlobal = false;   // Add VarTrackerName if it is global
+        private boolean hasSuffix = false;  // Add VarLocalSuffix if it is local
+        private String prefix = "";
+        private String name = "";
+
+        public Variable(){}
+        public Variable(String name){ this.name = name;}
+        public String toString(){ return ((isGlobal)? VarTrackerName : "") + prefix + name + ((hasSuffix)? VarLocalSuffix : "");}
+        public String getQualName(){ return this.toString(); }
+        public String getName(){ return name; }
+        public String getFullName(){ return prefix + name; }
+        public String getLocalName(){ return prefix + name + VarLocalSuffix; }
+        public void setPrefix(String prefix){this.prefix = prefix;}
+        public void setName(String name){this.name = name;}
+        public void setHasSuffix(boolean hasSuffix){this.hasSuffix = hasSuffix;}
+        public void setGlobal(boolean isGlobal){this.isGlobal = isGlobal;}
+        @Override
+        public int hashCode() { return Objects.hash(prefix, name); }
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) { return true; }
+            if (o == null || getClass() != o.getClass()) { return false; }
+            Variable variable = (Variable) o;
+            return Objects.equals(prefix, variable.prefix) &&
+                    Objects.equals(name, variable.name);
         }
-    	return varName;
+    }
+
+    public static class VariableSet implements Iterable<Variable> {
+        private final LinkedHashSet<Variable> vars = new LinkedHashSet<>();
+        public VariableSet(){}
+        public void add(Variable var){ vars.add(var); }
+        public boolean checkIntersection(VariableSet other){return !Collections.disjoint(getFullNamesSet(), other.getFullNamesSet());}
+        public List<String> getNames(){return vars.stream().map(Variable::getName).distinct().collect(Collectors.toList());}
+
+        public List<String> getFullNames(){ return vars.stream().map(Variable::getFullName).distinct().collect(Collectors.toList()); }
+        public Set<String> getFullNamesSet(){ return vars.stream().map(Variable::getFullName).collect(Collectors.toSet()); }
+
+        @Override
+        public Iterator<Variable> iterator() { return vars.iterator(); }
+        @Override
+        public void forEach(Consumer<? super Variable> action) { vars.forEach(action); }
+
+        public boolean contains(Variable var) { return vars.contains(var); }
     }
 }

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -266,7 +266,7 @@ public class DashPythonTranslation {
 
     private void initSignatures(List<Sig> signaturesSortedList){
         br = new BufferedReader(new InputStreamReader(System.in));
-        useSignatureConfig = false;
+        useSignatureConfig = true;      // TODO: clean up, currently set to true so it won't ask for using config file, also need to clean up the inputs in unit tests
         hasPromptedSigConfig = false;
         needToUpdateConfigFile = false;
         signatureJSONConfig = new JsonObject();

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -1105,7 +1105,7 @@ public class DashPythonTranslation {
                 DashExprToPython<DashDoExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap,DashExprToPython.ExprTypeE.DO);
 
                 this.actions = dashExprTranslator.toList();
-                this.assignableVarsFullNames = dashExprTranslator.getAssignableVars().getFullNames();
+                this.assignableVarsFullNames = dashExprTranslator.getAssignableVars().getFullNames().stream().sorted().collect(Collectors.toList());
 
                 invariantList.forEach(inv -> {
                     if(inv.getRelatedVariables().checkIntersection(dashExprTranslator.getAssignableVars())){

--- a/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
+++ b/org.alloytools.alloy.dash/src/main/java/ca/uwaterloo/watform/rapidDash/DashPythonTranslation.java
@@ -2,6 +2,7 @@ package ca.uwaterloo.watform.rapidDash;
 
 import ca.uwaterloo.watform.ast.*;
 import ca.uwaterloo.watform.parser.DashModule;
+import ca.uwaterloo.watform.rapidDash.DashExprToPython.VariableSet;
 import com.google.gson.*;
 import edu.mit.csail.sdg.alloy4.ErrorFatal;
 import edu.mit.csail.sdg.ast.*;
@@ -1068,8 +1069,8 @@ public class DashPythonTranslation {
         private String toStateName = "";
         private String transName = "";                       // transition name
         private List<String> actions = new ArrayList<>();    // the logic for this transition to be executed
-        private final List<String> invariants = new ArrayList<>();    // the logic for this transition to be executed
-        private List<String> assignableVars;
+        private final List<String> invariantNames = new ArrayList<>();    // the logic for this transition to be executed
+        private List<String> assignableVarsFullNames;
         private List<String> guardConditions = new ArrayList<>();   // the guard conditions of this transition
         private String eventCondition = "";
         private String triggerEvent = "";
@@ -1104,12 +1105,11 @@ public class DashPythonTranslation {
                 DashExprToPython<DashDoExpr> dashExprTranslator = new DashExprToPython<>(dashTrans.getAction(), variable2StateNameMap,DashExprToPython.ExprTypeE.DO);
 
                 this.actions = dashExprTranslator.toList();
-                this.assignableVars = dashExprTranslator.getAssignableVars();
-                Set<String> relatedDynamicVars = dashExprTranslator.getRelatedDynamicVars();
+                this.assignableVarsFullNames = dashExprTranslator.getAssignableVars().getFullNames();
 
                 invariantList.forEach(inv -> {
-                    if(!Collections.disjoint(relatedDynamicVars, inv.getRelatedVariables())){
-                        this.invariants.add(inv.getName());
+                    if(inv.getRelatedVariables().checkIntersection(dashExprTranslator.getAssignableVars())){
+                        this.invariantNames.add(inv.getInvariantCallName(dashExprTranslator.getAssignableVars()));
                     }
                 });
             }
@@ -1129,8 +1129,8 @@ public class DashPythonTranslation {
         public String getPythonVariableStateName() {return "ref_" + stateName.toLowerCase();}
         public List<String> getGuardConditions(){return guardConditions;}
         public List<String> getActions(){return actions;}
-        public List<String> getInvariantNames(){return invariants;}
-        public List<String> getAssignedVarNames(){return assignableVars;}
+        public List<String> getInvariantNames(){return invariantNames;}
+        public List<String> getAssignedVarNames(){return assignableVarsFullNames;}
         public String getEventCondition() {return eventCondition;}
         public String getFromStateName() {return fromStateName;}
         public String getToStateName() {return toStateName;}
@@ -1157,7 +1157,7 @@ public class DashPythonTranslation {
     public class Invariant{
         private String invariantName = "";                      // invariant name
         private List<String> conditions = new ArrayList<>();    // the logic for this invariant to be executed
-        private Set<String> relatedVariables = new HashSet<>(); // the variables that are related to this invariant
+        private VariableSet relatedVariables = new VariableSet(); // the variables that are related to this invariant
 
         public Invariant(DashInvariant dashInvariant){
             // set default invariant information
@@ -1165,13 +1165,22 @@ public class DashPythonTranslation {
 
             // determines the invariant condition
             if(dashInvariant.getExpr() != null){
-                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap);
+                DashExprToPython<Expr> dashExprTranslator = new DashExprToPython<>(dashInvariant.getExpr(), variable2StateNameMap, DashExprToPython.ExprTypeE.INV);
                 this.conditions = dashExprTranslator.toList();
                 this.relatedVariables = dashExprTranslator.getRelatedDynamicVars();
             }
         }
-        public String getName(){return invariantName;}
+        public String getInvariantName(){return invariantName + "(" + String.join(", ", relatedVariables.getNames()) + ")";}
         public List<String> getConditions(){return conditions;}
-        public Set<String> getRelatedVariables(){return relatedVariables;}
+        public VariableSet getRelatedVariables(){return relatedVariables;}
+        public String getInvariantCallName(VariableSet assignableVars){
+            // Put in the parameters according to the related variables given by the actions
+            List<String> list = new ArrayList<>();
+
+            // For each parameter in the parameters list, get the corresponding variable name
+            // if the variable is assigned in the actions, use the local name; otherwise, use the qualified name
+            relatedVariables.forEach(var -> list.add((assignableVars.contains(var)) ? var.getLocalName() : var.getQualName()));
+            return invariantName + "(" + String.join(", ", list) + ")";
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Add parameters in the invariant functions so it uses the arguments instead of the global variables (`SS.xxx`)
- Added `Variable` and `VariableSet` because the variable names are too complex and knowing all types of variable names will be handy. We also need a set of these variables so we can determine things like
   - The parameter names for each invariant
   - The argument names to pass into each invariant function call in different actions
- Updated the iterator so the elements returned by the iterator are also in type `MetaSet.Set` so they can use the operators

`Ehealth.dsh` is supported now.

Dash:
```
invariant symmetry {
    all m1, m2: Medication |
        m1 -> m2  in interactions iff m2 -> m1 in interactions
}

invariant no_self_interaction {
    all m: medications | not (m -> m in interactions)
}

invariant safe_prescriptions {
    all m1, m2: medications, p: patients |
        m1 -> m2 in interactions =>
            !((p -> m1 in prescriptions) and (p -> m2 in prescriptions))
}

trans add_patient {
    when !(in_p in patients)
    do patients' = patients + in_p
}

trans add_medication {
    when !(in_m1 in medications)
    do medications' = medications + in_m1
}
```
Python:
```
# --- Invariants ---
def Inv_symmetry(interactions) -> bool:
    return (all([(m1 * m2 in interactions) == (m2 * m1 in interactions) for m1 in Medication for m2 in Medication]))

def Inv_no_self_interaction(medications, interactions) -> bool:
    return (all([not(m * m in interactions) for m in medications]))

def Inv_safe_prescriptions(medications, patients, prescriptions) -> bool:
    return (all([(p * m1 in prescriptions and p * m2 in prescriptions) for m1 in medications for m2 in medications for p in patients]))

    # execution for add_patient
    def _trans_add_patient(self) -> bool:
        try:
            for EHealthSystem_patients_updated in SS.EHealthSystem_patients.possible_next_values():
                EHealthSystem_patients_updated = MetaSet.Set(set(EHealthSystem_patients_updated))
                if not Inv_safe_prescriptions(SS.EHealthSystem_medications, EHealthSystem_patients_updated, SS.EHealthSystem_prescriptions):
                    continue
                if EHealthSystem_patients_updated == SS.EHealthSystem_patients + SS.EHealthSystem_in_p:
                    raise MultiLevelExit
        except MultiLevelExit:
            SS.EHealthSystem_patients = EHealthSystem_patients_updated
        else:
            print("No possible next state values")
            exit(1)
        print(Blue + "Taking transition add_patient" + Reset)
        # Apply State Activeness Changes
        states_becoming_active = [ref_ehealthsystem]
        for state in states_becoming_active:
            state.is_active = True
        return True

    # execution for add_medication
    def _trans_add_medication(self) -> bool:
        try:
            for EHealthSystem_medications_updated in SS.EHealthSystem_medications.possible_next_values():
                EHealthSystem_medications_updated = MetaSet.Set(set(EHealthSystem_medications_updated))
                if not (Inv_no_self_interaction(EHealthSystem_medications_updated, SS.EHealthSystem_interactions) and
                    Inv_safe_prescriptions(EHealthSystem_medications_updated, SS.EHealthSystem_patients, SS.EHealthSystem_prescriptions)):
                    continue
                if EHealthSystem_medications_updated == SS.EHealthSystem_medications + SS.EHealthSystem_in_m1:
                    raise MultiLevelExit
        except MultiLevelExit:
            SS.EHealthSystem_medications = EHealthSystem_medications_updated
        else:
            print("No possible next state values")
            exit(1)
        print(Blue + "Taking transition add_medication" + Reset)
        # Apply State Activeness Changes
        states_becoming_active = [ref_ehealthsystem]
        for state in states_becoming_active:
            state.is_active = True
        return True
```
