### PR TITLE
Add dependencies

### DIFF
--- a/org.alloytools.alloy.dashbuild/bnd.bnd
+++ b/org.alloytools.alloy.dashbuild/bnd.bnd
@@ -1,4 +1,4 @@
-Main-Class: ca.uwaterloo.watform.dash4whole.Dash
+Main-Class: ca.uwaterloo.watform.dash4whole.RapidDash
 
 -buildpath: \
 	org.alloytools.alloy.application,\
@@ -23,4 +23,7 @@ Main-Class: ca.uwaterloo.watform.dash4whole.Dash
 	@${repo;org.sat4j.core}, \
 	@${repo;org.sat4j.maxsat}, \
 	@${repo;org.sat4j.pb}, \
+	@/Users/jianyanli/Projects/org.alloytools.alloy/cnf/jars/velocity-engine-core-2.3.jar, \
+	@/Users/jianyanli/Projects/org.alloytools.alloy/cnf/jars/gson-2.8.2.jar, \
+	@/Users/jianyanli/Projects/org.alloytools.alloy/cnf/jars/commons-lang3-3.12.0.jar, \
 	LICENSES


### PR DESCRIPTION
Let's not merge this, but use this branch to make the jar file.

run ` java -jar /Users/jianyanli/Projects/org.alloytools.alloy/org.alloytools.alloy.dashbuild/target/org.alloytools.alloy.dashbuild.jar` to use the jar.

We are downloading packages manually instead of idiomatically (adding them to cenral.mvn), let's fix that in the future. 